### PR TITLE
changed blmod_exp_startpars so that AIF can contain negatives or zeros

### DIFF
--- a/R/kinfitr_bloodmodels.R
+++ b/R/kinfitr_bloodmodels.R
@@ -288,7 +288,8 @@ blmod_exp_startpars <- function(time, activity, fit_exp3=TRUE,
   blood_exp_part3 <- dplyr::filter(blood_decay,
                                    dplyr::between(time,
                                                   expdecay_props[2]*max(time),
-                                                  max(time)))
+                                                  max(time)) &
+                                     activity>0)
 
   exp3_mod <- lm(log(abs(activity)) ~ time,
                  data=blood_exp_part3)
@@ -316,7 +317,8 @@ blmod_exp_startpars <- function(time, activity, fit_exp3=TRUE,
   blood_exp_part2 <- dplyr::filter(blood_decay,
                                    dplyr::between(time,
                                                   expdecay_props[1]*max(time),
-                                                  expdecay_props[2]*max(time)))
+                                                  expdecay_props[2]*max(time)) &
+                                     activity_2ex>0)
 
   if(fit_exp3) {
 
@@ -342,7 +344,8 @@ blmod_exp_startpars <- function(time, activity, fit_exp3=TRUE,
   blood_exp_part1 <- dplyr::filter(blood_decay,
                                    dplyr::between(time,
                                                   min(time),
-                                                  expdecay_props[1]*max(time)))
+                                                  expdecay_props[1]*max(time)) &
+                                     activity_1ex>0)
 
   exp1_mod <- lm(log(abs(activity_1ex)) ~ time,
                  data=blood_exp_part1)

--- a/tests/testthat/test-blooddata.R
+++ b/tests/testthat/test-blooddata.R
@@ -137,6 +137,26 @@ test_that("bloodsplines works", {
   expect_true(any(class(bdplot) == "ggplot"))
 })
 
+test_that("starting parameters for expontial when AIF contains zeros works", {
+
+  aif <- bd_getdata(blooddata, output = "AIF")
+
+  aif$aif[100] <- 0
+  aif$aif[500] <- 0
+  aif$aif[length(aif$aif)] <- -1
+  aif$aif[length(aif$aif)-1] <- 0
+
+  start <- blmod_exp_startpars(aif$time,
+                               aif$aif,
+                               fit_exp3 = T,
+                               expdecay_props = c(1/60, 0.1))
+
+
+
+  expect_true(any(class(start) == "list"))
+
+})
+
 test_that("exponential works", {
 
   aif <- bd_getdata(blooddata, output = "AIF")


### PR DESCRIPTION
blmod_exp_startpars now works if AIF contains data points that are negative or zero. Updated testthat to test if blmod_exp_startpars works when there are AIF have data points <= 0.