### PR TITLE
Added parentheses to denominator of disp-corr equation

### DIFF
--- a/R/kinfitr_bloodfuncs.R
+++ b/R/kinfitr_bloodfuncs.R
@@ -582,7 +582,7 @@ blood_dispcor <- function(time, activity, tau, timedelta = NULL,
   ind <- 2:(length(i_time) - 1)
 
   time_out <- i_time[ind]
-  activity_out <- (i_integ_true[ind + 1] - i_integ_true[ind - 1]) / 2 * timedelta
+  activity_out <- (i_integ_true[ind + 1] - i_integ_true[ind - 1]) / (2 * timedelta)
 
   out <- tibble::tibble(time = time_out, activity = activity_out)
 


### PR DESCRIPTION
In order to adhere to eq9 from TPC http://www.turkupetcentre.net/petanalysis/input_dispersion.html I added a parentheses around to line 595 to make both `2` and `timedelta` appear in the denominator. 