### PR TITLE
Added a fix for a potential edge case with blmod_exp_startpars()

### DIFF
--- a/R/kinfitr_bloodmodels.R
+++ b/R/kinfitr_bloodmodels.R
@@ -303,6 +303,17 @@ blmod_exp_startpars <- function(time, activity, fit_exp3=TRUE,
   rise_coef <- coef(rise_lm)
   startpars$t0 <- as.numeric(-1*(rise_coef[1]/rise_coef[2]))
 
+  if(startpars$t0 < 0) { # This can happen if the peak is very dispersed
+    bloodrise <- bloodrise[blood$activity >= 0.1*startpars$peakval, ]
+    rise_lm <- lm(activity ~ time, data=bloodrise)
+    rise_coef <- coef(rise_lm)
+    startpars$t0 <- as.numeric(-1*(rise_coef[1]/rise_coef[2]))
+  }
+
+  if(startpars$t0 < 0) { # If still less than 0
+    startpars$t0 <- 0
+  }
+
   # Decay
   blood_decay <- blood[blood$time > startpars$peaktime,]
   blood_decay$time <- blood_decay$time - startpars$peaktime


### PR DESCRIPTION
When the peak is highly diffuse, the automatically generated startpar can be negative.  I've added a fix for this, first trying drawing a line through only the points greater than 10% of the peak, with no weighting, and secondly just setting it to zero if it's still negative.