### PR TITLE
Fixed default predict output for blmod_splines

### DIFF
--- a/R/kinfitr_bloodmodels.R
+++ b/R/kinfitr_bloodmodels.R
@@ -190,6 +190,10 @@ predict.blood_splines <- function(object, newdata = NULL) {
     pred_before <- predict(object$before)
     pred_x_before <- object$before$model$time
 
+    # Remove our extra point before the peak
+    pred_before <- pred_before[-length(pred_before)]
+    pred_x_before <- pred_x_before[-length(pred_x_before)]
+
     pred_after_d <- predict(object$after_d)
     pred_x_after_d <- object$after_d$model$time
 


### PR DESCRIPTION
The default predict method for blmod_splines produced one too many points when newdata was not specified.  This fixes that.  This will not change the behaviour when newdata is actually provided, as we do with blooddata - this is just for doing stuff outside of blooddata objects.