### PR TITLE
FIX: update unitless to arbitrary for metabolite data in BIDS parsing

### DIFF
--- a/R/kinfitr_bids.R
+++ b/R/kinfitr_bids.R
@@ -321,7 +321,7 @@ bids_parse_blood <- function(filedata) {
     pf_desc <- list(jsondat_blood_discrete[c("time")])
     pf_desc$parentFraction <- list(Description =
                             "All set to 1 because no metabolite data available",
-                            Units = "unitless")
+                            Units = "arbitrary")
   }
 
   ### No whole blood, only plasma: use plasma as blood
@@ -387,7 +387,7 @@ bids_parse_blood <- function(filedata) {
     }
   }
 
-  if( MetaboliteData$parentFraction$Units != "unitless" ) {
+  if( MetaboliteData$parentFraction$Units != "arbitrary" ) {
       stop(paste("Unrecognised parentFraction units for Metabolite:",
                  MetaboliteData$parentFraction$Units))
   }


### PR DESCRIPTION
This PR updates the BIDS parsing for PET blood data as mentioned in issue https://github.com/mathesong/kinfitr/issues/22. This will allow metabolite data with units "arbitrary" to be parsed in accordance with the BIDS specification. 