### PR TITLE
Fix the blood_interp bug

### DIFF
--- a/R/kinfitr_bloodfuncs.R
+++ b/R/kinfitr_bloodfuncs.R
@@ -119,13 +119,15 @@ blood_interp <- function(t_blood, blood,
   interptime <- pracma::linspace(0, maxtime, interpPoints)
 
   interpcurves <- input %>%
-    dplyr::group_split(Measure) %>%
-    purrr::map(~ pracma::interp1(.x$Time,
-        .x$Value,
-        interptime,
-        method = "linear"
-      )) %>%
-    purrr::set_names(unique(input$Measure))
+    dplyr::group_by(Measure) %>%  # Add group_by here!
+    dplyr::group_split() %>%
+    purrr::map(~{
+      measure_name <- unique(.x$Measure)
+      values <- pracma::interp1(.x$Time, .x$Value, interptime, method = "linear")
+      list(measure = measure_name, values = values)
+    }) %>%
+    purrr::set_names(purrr::map_chr(., "measure")) %>%
+    purrr::map("values")
 
   if(is.null(aif)) {
 


### PR DESCRIPTION
Fixed a small issue with the blood_interp function when an AIF was present, resulting in strange values for the parent fraction (which didn't affect the AIF), but resulted in weird-looking plots.