### PR TITLE
Fix tstar time with timestartend

### DIFF
--- a/R/kinfitr_bids.R
+++ b/R/kinfitr_bids.R
@@ -655,6 +655,10 @@ bids_create_blooddata <- function(filedata) {
 
   bids_data <- bids_parse_blood(filedata)
 
+  if(length(bids_data) == 1) {
+    return(list(NA))
+  }
+
   blooddata <- list(
     Data = bids_data,
     Models = list(

--- a/R/kinfitr_loganplot.R
+++ b/R/kinfitr_loganplot.R
@@ -11,9 +11,9 @@
 #' @param input Data frame containing the blood, plasma, and parent fraction
 #'   concentrations over time.  This can be generated using the
 #'   \code{blood_interp} function.
-#' @param tstar The t* specification for regression. If tstar_type="frames", 
+#' @param tstar The t* specification for regression. If tstar_type="frames",
 #'   this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#'   If tstar_type="time", this is the time point (in minutes) after which all frames 
+#'   If tstar_type="time", this is the time point (in minutes) after which all frames
 #'   with midpoints later than this time are included. This value can be estimated using \code{Logan_tstar}.
 #' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
 #' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
@@ -77,7 +77,7 @@ Loganplot <- function(t_tac, tac, input, tstar, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -101,14 +101,6 @@ Loganplot <- function(t_tac, tac, input, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_art(t_tac, tac, weights, frameStartEnd)
@@ -121,6 +113,14 @@ Loganplot <- function(t_tac, tac, input, tstar, weights = NULL,
   t_tac <- tidyinput$t_tac
   tac <- tidyinput$tac
   weights <- tidyinput$weights
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
   newvals <- shift_timings(
     t_tac = t_tac,

--- a/R/kinfitr_ma1.R
+++ b/R/kinfitr_ma1.R
@@ -87,14 +87,6 @@ ma1 <- function(t_tac, tac, input, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_art(t_tac, tac, weights, frameStartEnd)
@@ -107,6 +99,16 @@ ma1 <- function(t_tac, tac, input, tstar, weights = NULL,
   t_tac <- tidyinput$t_tac
   tac <- tidyinput$tac
   weights <- tidyinput$weights
+
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
+
 
   newvals <- shift_timings(
     t_tac = t_tac,

--- a/R/kinfitr_mlloganplot.R
+++ b/R/kinfitr_mlloganplot.R
@@ -8,9 +8,9 @@
 #' zero: if not included, it is added.
 #' @param input Data frame containing the blood, plasma, and parent fraction concentrations over time.  This can be generated
 #' using the \code{blood_interp} function.
-#' @param tstar The t* specification for regression. If tstar_type="frames", 
+#' @param tstar The t* specification for regression. If tstar_type="frames",
 #' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames 
+#' If tstar_type="time", this is the time point (in minutes) after which all frames
 #' with midpoints later than this time are included. This value can be estimated using \code{mlLogan_tstar}.
 #' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
 #' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
@@ -65,7 +65,7 @@ mlLoganplot <- function(t_tac, tac, input, tstar, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -89,14 +89,6 @@ mlLoganplot <- function(t_tac, tac, input, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_art(t_tac, tac, weights, frameStartEnd)
@@ -110,6 +102,14 @@ mlLoganplot <- function(t_tac, tac, input, tstar, weights = NULL,
   tac <- tidyinput$tac
   weights <- tidyinput$weights
 
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
   newvals <- shift_timings(
     t_tac = t_tac,
@@ -304,7 +304,7 @@ plot_mlLoganfit <- function(mlloganout, roiname = NULL) {
 mlLogan_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL, inpshift = 0, vB = 0, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/R/kinfitr_mrtm1.R
+++ b/R/kinfitr_mrtm1.R
@@ -13,9 +13,9 @@
 #' @param roitac Numeric vector of radioactivity concentrations in the target
 #'   tissue for each frame. We include zero at time zero: if not included, it is
 #'   added.
-#' @param tstar Optional. The t* specification for regression. If tstar_type="frames", 
+#' @param tstar Optional. The t* specification for regression. If tstar_type="frames",
 #'   this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#'   If tstar_type="time", this is the time point (in minutes) after which all frames 
+#'   If tstar_type="time", this is the time point (in minutes) after which all frames
 #'   with midpoints later than this time are included. This value can be estimated using \code{mrtm1_tstar}.
 #'   Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
 #'   pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames
@@ -69,7 +69,7 @@ mrtm1 <- function(t_tac, reftac, roitac, tstar = NULL, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -81,19 +81,6 @@ mrtm1 <- function(t_tac, reftac, roitac, tstar = NULL, weights = NULL,
     }
     tstar <- tstarIncludedFrames
     tstar_type <- "frames"
-  }
-
-  # Validate tstar_type
-  if (!is.null(tstar)) {
-    tstar_type <- match.arg(tstar_type, c("frames", "time"))
-    
-    # Convert tstar based on type
-    if (tstar_type == "time") {
-      frames_after_tstar <- which(t_tac >= tstar)
-      tstarIncludedFrames <- length(frames_after_tstar)
-    } else {
-      tstarIncludedFrames <- tstar
-    }
   }
 
   # Tidying
@@ -109,6 +96,19 @@ mrtm1 <- function(t_tac, reftac, roitac, tstar = NULL, weights = NULL,
   reftac <- tidyinput$reftac
   roitac <- tidyinput$roitac
   weights <- tidyinput$weights
+
+  # Validate tstar_type
+  if (!is.null(tstar)) {
+    tstar_type <- match.arg(tstar_type, c("frames", "time"))
+
+    # Convert tstar based on type
+    if (tstar_type == "time") {
+      frames_after_tstar <- which(t_tac >= tstar)
+      tstarIncludedFrames <- length(frames_after_tstar)
+    } else {
+      tstarIncludedFrames <- tstar
+    }
+  }
 
   if (is.null(tstarIncludedFrames)) {
     tstarIncludedFrames <- length(reftac)
@@ -239,7 +239,7 @@ plot_mrtm1fit <- function(mrtm1out, roiname = NULL, refname = NULL) {
     refname <- "Reference"
   }
 
-  measured <- dplyr::rename(measured, 
+  measured <- dplyr::rename(measured,
     !!paste0(roiname, ".measured") := ROI.measured,
     !!refname := Reference
   )
@@ -318,7 +318,7 @@ plot_mrtm1fit <- function(mrtm1out, roiname = NULL, refname = NULL) {
 mrtm1_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = NULL, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/R/kinfitr_mrtm2.R
+++ b/R/kinfitr_mrtm2.R
@@ -17,9 +17,9 @@
 #'   tissue-to-plasma clearance rate. This can be obtained from MRTM1 of SRTM,
 #'   or set at a specified value. If using SRTM to estimate this value, it is
 #'   equal to k2 / R1.
-#' @param tstar Optional. The t* specification for regression. If tstar_type="frames", 
+#' @param tstar Optional. The t* specification for regression. If tstar_type="frames",
 #'   this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#'   If tstar_type="time", this is the time point (in minutes) after which all frames 
+#'   If tstar_type="time", this is the time point (in minutes) after which all frames
 #'   with midpoints later than this time are included. This value can be estimated using \code{mrtm2_tstar}.
 #'   Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
 #'   pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames
@@ -75,7 +75,7 @@ mrtm2 <- function(t_tac, reftac, roitac, k2prime, tstar = NULL, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -87,19 +87,6 @@ mrtm2 <- function(t_tac, reftac, roitac, k2prime, tstar = NULL, weights = NULL,
     }
     tstar <- tstarIncludedFrames
     tstar_type <- "frames"
-  }
-
-  # Validate tstar_type
-  if (!is.null(tstar)) {
-    tstar_type <- match.arg(tstar_type, c("frames", "time"))
-    
-    # Convert tstar based on type
-    if (tstar_type == "time") {
-      frames_after_tstar <- which(t_tac >= tstar)
-      tstarIncludedFrames <- length(frames_after_tstar)
-    } else {
-      tstarIncludedFrames <- tstar
-    }
   }
 
   # Tidying
@@ -115,6 +102,19 @@ mrtm2 <- function(t_tac, reftac, roitac, k2prime, tstar = NULL, weights = NULL,
   reftac <- tidyinput$reftac
   roitac <- tidyinput$roitac
   weights <- tidyinput$weights
+
+  # Validate tstar_type
+  if (!is.null(tstar)) {
+    tstar_type <- match.arg(tstar_type, c("frames", "time"))
+
+    # Convert tstar based on type
+    if (tstar_type == "time") {
+      frames_after_tstar <- which(t_tac >= tstar)
+      tstarIncludedFrames <- length(frames_after_tstar)
+    } else {
+      tstarIncludedFrames <- tstar
+    }
+  }
 
   if (is.null(tstarIncludedFrames)) {
     tstarIncludedFrames <- length(reftac)
@@ -236,7 +236,7 @@ plot_mrtm2fit <- function(mrtm2out, roiname = NULL, refname = NULL) {
     refname <- "Reference"
   }
 
-  measured <- dplyr::rename(measured, 
+  measured <- dplyr::rename(measured,
     !!paste0(roiname, ".measured") := ROI.measured,
     !!refname := Reference
   )
@@ -305,7 +305,7 @@ plot_mrtm2fit <- function(mrtm2out, roiname = NULL, refname = NULL) {
 mrtm2_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, filename = NULL, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/R/kinfitr_patlakplot.R
+++ b/R/kinfitr_patlakplot.R
@@ -95,14 +95,6 @@ Patlakplot <- function(t_tac, tac, input, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_art(t_tac, tac, weights, frameStartEnd)
@@ -110,6 +102,15 @@ Patlakplot <- function(t_tac, tac, input, tstar, weights = NULL,
   t_tac <- tidyinput$t_tac
   tac <- tidyinput$tac
   weights <- tidyinput$weights
+
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
 
   newvals <- shift_timings(

--- a/R/kinfitr_refPatlak.R
+++ b/R/kinfitr_refPatlak.R
@@ -8,9 +8,9 @@
 #' time zero: if not included, it is added.
 #' @param roitac Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
 #' zero: if not included, it is added.
-#' @param tstar The t* specification for regression. If tstar_type="frames", 
+#' @param tstar The t* specification for regression. If tstar_type="frames",
 #' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames 
+#' If tstar_type="time", this is the time point (in minutes) after which all frames
 #' with midpoints later than this time are included. This value can be estimated using \code{refPatlak_tstar}.
 #' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
 #' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
@@ -50,7 +50,7 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -74,14 +74,6 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_ref(t_tac, reftac, roitac, weights, frameStartEnd)
@@ -96,6 +88,13 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
   roitac <- tidyinput$roitac
   weights <- tidyinput$weights
 
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
   # Parameters
 
@@ -243,7 +242,7 @@ plot_refPatlakfit <- function(refpatlakout, roiname = NULL) {
 refPatlak_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = NULL, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/R/kinfitr_reflogan.R
+++ b/R/kinfitr_reflogan.R
@@ -10,9 +10,9 @@
 #' zero: if not included, it is added.
 #' @param k2prime Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
 #' obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.
-#' @param tstar The t* specification for regression. If tstar_type="frames", 
+#' @param tstar The t* specification for regression. If tstar_type="frames",
 #' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames 
+#' If tstar_type="time", this is the time point (in minutes) after which all frames
 #' with midpoints later than this time are included. This value can be estimated using \code{refLogan_tstar}.
 #' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
 #' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
@@ -52,7 +52,7 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -76,14 +76,6 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_ref(t_tac, reftac, roitac, weights, frameStartEnd)
@@ -97,6 +89,14 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
   reftac <- tidyinput$reftac
   roitac <- tidyinput$roitac
   weights <- tidyinput$weights
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
   # Parameters
 
@@ -246,7 +246,7 @@ plot_refLoganfit <- function(refloganout, roiname = NULL) {
 refLogan_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, filename = NULL, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/R/kinfitr_refmllogan.R
+++ b/R/kinfitr_refmllogan.R
@@ -10,9 +10,9 @@
 #' zero: if not included, it is added.
 #' @param k2prime Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
 #' obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.
-#' @param tstar The t* specification for regression. If tstar_type="frames", 
+#' @param tstar The t* specification for regression. If tstar_type="frames",
 #' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames 
+#' If tstar_type="time", this is the time point (in minutes) after which all frames
 #' with midpoints later than this time are included. This value can be estimated using \code{refmlLogan_tstar}.
 #' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
 #' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
@@ -50,7 +50,7 @@ refmlLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
 
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 
@@ -74,14 +74,6 @@ refmlLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
     warning("No value specified for tstar: defaulting to including all frames. This may produce biased outcomes.", call. = FALSE)
   }
 
-  # Convert tstar based on type
-  if (tstar_type == "time") {
-    frames_after_tstar <- which(t_tac >= tstar)
-    tstarIncludedFrames <- length(frames_after_tstar)
-  } else {
-    tstarIncludedFrames <- tstar
-  }
-
   # Tidying
 
   tidyinput <- tidyinput_ref(t_tac, reftac, roitac, weights, frameStartEnd)
@@ -95,6 +87,14 @@ refmlLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
   reftac <- tidyinput$reftac
   roitac <- tidyinput$roitac
   weights <- tidyinput$weights
+
+  # Convert tstar based on type
+  if (tstar_type == "time") {
+    frames_after_tstar <- which(t_tac >= tstar)
+    tstarIncludedFrames <- length(frames_after_tstar)
+  } else {
+    tstarIncludedFrames <- tstar
+  }
 
   # Parameters
 
@@ -253,7 +253,7 @@ plot_refmlLoganfit <- function(refmlloganout, roiname = NULL) {
 refmlLogan_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, filename = NULL, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   # Convert timeStartEnd to frameStartEnd if needed
   if (is.null(frameStartEnd) && !is.null(timeStartEnd)) {
-    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1], 
+    frameStartEnd <- c(which(t_tac >= timeStartEnd[1])[1],
                        tail(which(t_tac <= timeStartEnd[2]), 1))
   }
 

--- a/man/Loganplot.Rd
+++ b/man/Loganplot.Rd
@@ -32,9 +32,9 @@ added.}
 concentrations over time.  This can be generated using the
 \code{blood_interp} function.}
 
-\item{tstar}{The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{Logan_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame

--- a/man/mlLoganplot.Rd
+++ b/man/mlLoganplot.Rd
@@ -29,9 +29,9 @@ zero: if not included, it is added.}
 \item{input}{Data frame containing the blood, plasma, and parent fraction concentrations over time.  This can be generated
 using the \code{blood_interp} function.}
 
-\item{tstar}{The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{mlLogan_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:

--- a/man/mrtm1.Rd
+++ b/man/mrtm1.Rd
@@ -30,9 +30,9 @@ added.}
 tissue for each frame. We include zero at time zero: if not included, it is
 added.}
 
-\item{tstar}{Optional. The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{Optional. The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{mrtm1_tstar}.
 Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
 pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames

--- a/man/mrtm2.Rd
+++ b/man/mrtm2.Rd
@@ -36,9 +36,9 @@ tissue-to-plasma clearance rate. This can be obtained from MRTM1 of SRTM,
 or set at a specified value. If using SRTM to estimate this value, it is
 equal to k2 / R1.}
 
-\item{tstar}{Optional. The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{Optional. The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{mrtm2_tstar}.
 Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
 pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames

--- a/man/refLogan.Rd
+++ b/man/refLogan.Rd
@@ -31,9 +31,9 @@ zero: if not included, it is added.}
 \item{k2prime}{Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
 obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.}
 
-\item{tstar}{The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{refLogan_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:

--- a/man/refPatlak.Rd
+++ b/man/refPatlak.Rd
@@ -27,9 +27,9 @@ time zero: if not included, it is added.}
 \item{roitac}{Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
 zero: if not included, it is added.}
 
-\item{tstar}{The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{refPatlak_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:

--- a/man/refmlLogan.Rd
+++ b/man/refmlLogan.Rd
@@ -31,9 +31,9 @@ zero: if not included, it is added.}
 \item{k2prime}{Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
 obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.}
 
-\item{tstar}{The t* specification for regression. If tstar_type="frames", 
+\item{tstar}{The t* specification for regression. If tstar_type="frames",
 this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames 
+If tstar_type="time", this is the time point (in minutes) after which all frames
 with midpoints later than this time are included. This value can be estimated using \code{refmlLogan_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:


### PR DESCRIPTION
There was an issue with selection of the appropriate frame for t* for a given time point when there was a timeStartEnd set. This is now resolved.