### PR TITLE
Fixes: tstarIncluded frames and add se

### DIFF
--- a/R/kinfitr_loganplot.R
+++ b/R/kinfitr_loganplot.R
@@ -328,9 +328,9 @@ plot_Loganfit <- function(loganout, roiname = NULL) {
 
 Logan_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL, inpshift = 0, vB = 0.05, frameStartEnd = NULL, timeStartEnd = NULL, gridbreaks = 2) {
   frames <- length(t_tac)
-  lowroi_fit <- Loganplot(t_tac, lowroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  medroi_fit <- Loganplot(t_tac, medroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  highroi_fit <- Loganplot(t_tac, highroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  lowroi_fit <- Loganplot(t_tac, lowroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  medroi_fit <- Loganplot(t_tac, medroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  highroi_fit <- Loganplot(t_tac, highroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
   # xlabel <- "Integ(C_Plasma)/C_Tissue"
   # ylabel <- "Integ(C_Tissue)/C_Tissue"
@@ -359,9 +359,9 @@ Logan_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL, 
   vt_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- Loganplot(t_tac, lowroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    medfit <- Loganplot(t_tac, medroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    highfit <- Loganplot(t_tac, highroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    lowfit <- Loganplot(t_tac, lowroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    medfit <- Loganplot(t_tac, medroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    highfit <- Loganplot(t_tac, highroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_ma1.R
+++ b/R/kinfitr_ma1.R
@@ -324,9 +324,9 @@ ma1_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL, in
   }
 
   frames <- length(t_tac)
-  lowroi_fit <- ma1(t_tac, lowroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  medroi_fit <- ma1(t_tac, medroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  highroi_fit <- ma1(t_tac, highroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  lowroi_fit <- ma1(t_tac, lowroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  medroi_fit <- ma1(t_tac, medroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  highroi_fit <- ma1(t_tac, highroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
   low_linplot <- plot_ma1fit(lowroi_fit) + ggtitle("Low") + ylim(0, max(lowroi_fit$tacs$Target * 1.1)) + theme(legend.position = "none")
   med_linplot <- plot_ma1fit(medroi_fit) + ggtitle("Medium") + ylim(0, max(medroi_fit$tacs$Target * 1.1)) + theme(legend.position = "none")
@@ -340,9 +340,9 @@ ma1_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL, in
   vt_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- ma1(t_tac, lowroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    medfit <- ma1(t_tac, medroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    highfit <- ma1(t_tac, highroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    lowfit <- ma1(t_tac, lowroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    medfit <- ma1(t_tac, medroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    highfit <- ma1(t_tac, highroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_miscfuncs.R
+++ b/R/kinfitr_miscfuncs.R
@@ -306,7 +306,7 @@ tidyinput_art <- function(t_tac, tac, weights, frameStartEnd) {
 #' roitac <- pbr28$tacs[[2]]$STR
 #' weights <- pbr28$tacs[[2]]$Weights
 #'
-#' refloganout <- refLogan(t_tac, reftac, roitac, 0.1, tstarIncludedFrames = 9)
+#' refloganout <- refLogan(t_tac, reftac, roitac, 0.1, tstar = 9)
 #'
 #' maxpercres(refloganout)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}

--- a/R/kinfitr_mlloganplot.R
+++ b/R/kinfitr_mlloganplot.R
@@ -309,9 +309,9 @@ mlLogan_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL
   }
 
   frames <- length(t_tac)
-  lowroi_fit <- mlLoganplot(t_tac, lowroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  medroi_fit <- mlLoganplot(t_tac, medroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  highroi_fit <- mlLoganplot(t_tac, highroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  lowroi_fit <- mlLoganplot(t_tac, lowroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  medroi_fit <- mlLoganplot(t_tac, medroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  highroi_fit <- mlLoganplot(t_tac, highroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
   xlabel <- "Fitted Values"
   ylabel <- expression(paste("", "", integral(, paste("0"), paste("", "t")),
@@ -329,9 +329,9 @@ mlLogan_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL
   vt_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- mlLoganplot(t_tac, lowroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    medfit <- mlLoganplot(t_tac, medroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    highfit <- mlLoganplot(t_tac, highroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    lowfit <- mlLoganplot(t_tac, lowroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    medfit <- mlLoganplot(t_tac, medroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    highfit <- mlLoganplot(t_tac, highroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_mrtm1.R
+++ b/R/kinfitr_mrtm1.R
@@ -13,20 +13,23 @@
 #' @param roitac Numeric vector of radioactivity concentrations in the target
 #'   tissue for each frame. We include zero at time zero: if not included, it is
 #'   added.
-#' @param tstar Optional. The t* specification for regression. If tstar_type="frames",
-#'   this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#'   If tstar_type="time", this is the time point (in minutes) after which all frames
-#'   with midpoints later than this time are included. This value can be estimated using \code{mrtm1_tstar}.
-#'   Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
-#'   pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames
-#'   can be used provided that the kinetics in the target tissue can be
-#'   described by a one tissue compartment (1TC) model (like SRTM). If this is
-#'   not the case, a t* is required. If the number of included frames is greater
-#'   than the number of frames minus 2, then the par output will also include R1
-#'   and k2 values. These parameters are only applicable if 1TC dynamics can be
-#'   assumed.
-#' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
-#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
+#' @param tstar Optional. The t* specification for regression. If
+#'   tstar_type="frames", this is the number of frames from the end to include
+#'   (e.g., 10 means last 10 frames). If tstar_type="time", this is the time
+#'   point (in minutes) after which all frames with midpoints later than this
+#'   time are included. This value can be estimated using \code{mrtm1_tstar}.
+#'   Note that this t* differs from that of the non-invasive Logan plot (which
+#'   is the point at which pseudo-equilibrium is reached). Rather, with MRTM1
+#'   and MRTM2, all frames can be used provided that the kinetics in the target
+#'   tissue can be described by a one tissue compartment (1TC) model (like
+#'   SRTM). If this is not the case, a t* is required. If the number of included
+#'   frames is greater than the number of frames minus 2, then the par output
+#'   will also include R1 and k2 values. These parameters are only applicable if
+#'   1TC dynamics can be assumed.
+#' @param tstar_type Either "frames" (default) or "time", specifying how to
+#'   interpret tstar.
+#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"'
+#'   instead.
 #' @param weights Optional. Numeric vector of the weights assigned to each frame
 #'   in the fitting. We include zero at time zero: if not included, it is added.
 #'   If not specified, uniform weights will be used.
@@ -34,8 +37,13 @@
 #'   not included, the integrals will be calculated using trapezoidal
 #'   integration.
 #' @param frameStartEnd Optional: This allows one to specify the beginning and
-#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess time stability for example.
-#' @param timeStartEnd Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.
+#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess
+#'   time stability for example.
+#' @param timeStartEnd Optional. This allows one to specify the beginning and
+#'   end time point instead of defining the frame numbers using frameStartEnd.
+#'   This function will restrict the model to all time frames whose t_tac is
+#'   between the values, i.e. c(0,5) will select all frames with midtimes during
+#'   the first 5 minutes.
 
 #'
 #' @return A list with a data frame of the fitted parameters \code{out$par},
@@ -354,9 +362,9 @@ mrtm1_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = NULL,
   bp_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- mrtm1(t_tac, reftac, lowroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    medfit <- mrtm1(t_tac, reftac, medroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    highfit <- mrtm1(t_tac, reftac, highroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    lowfit <- mrtm1(t_tac, reftac, lowroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    medfit <- mrtm1(t_tac, reftac, medroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    highfit <- mrtm1(t_tac, reftac, highroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_mrtm2.R
+++ b/R/kinfitr_mrtm2.R
@@ -340,9 +340,9 @@ mrtm2_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, filenam
   bp_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- mrtm2(t_tac, reftac, lowroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    medfit <- mrtm2(t_tac, reftac, medroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    highfit <- mrtm2(t_tac, reftac, highroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    lowfit <- mrtm2(t_tac, reftac, lowroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    medfit <- mrtm2(t_tac, reftac, medroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    highfit <- mrtm2(t_tac, reftac, highroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_patlakplot.R
+++ b/R/kinfitr_patlakplot.R
@@ -12,11 +12,14 @@
 #'   concentrations over time.  This can be generated using the
 #'   \code{blood_interp} function.
 #' @param tstar The t* specification for regression. If tstar_type="frames",
-#'   this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#'   If tstar_type="time", this is the time point (in minutes) after which all frames
-#'   with midpoints later than this time are included. This value can be estimated using \code{Patlak_tstar}.
-#' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
-#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
+#'   this is the number of frames from the end to include (e.g., 10 means last
+#'   10 frames). If tstar_type="time", this is the time point (in minutes) after
+#'   which all frames with midpoints later than this time are included. This
+#'   value can be estimated using \code{Patlak_tstar}.
+#' @param tstar_type Either "frames" (default) or "time", specifying how to
+#'   interpret tstar.
+#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"'
+#'   instead.
 #' @param weights Optional. Numeric vector of the weights assigned to each frame
 #'   in the fitting. We include zero at time zero: if not included, it is added.
 #'   If not specified, uniform weights will be used.
@@ -28,18 +31,23 @@
 #'   prior to parameter estimation using the following equation: \deqn{C_{T}(t)
 #'   = \frac{C_{Measured}(t) - vB\times C_{B}(t)}{1-vB}}
 #' @param frameStartEnd Optional: This allows one to specify the beginning and
-#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess time stability for example.
-#' @param timeStartEnd Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.
+#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess
+#'   time stability for example.
+#' @param timeStartEnd Optional. This allows one to specify the beginning and
+#'   end time point instead of defining the frame numbers using frameStartEnd.
+#'   This function will restrict the model to all time frames whose t_tac is
+#'   between the values, i.e. c(0,5) will select all frames with midtimes during
+#'   the first 5 minutes.
 #'
 #'
-#' @return A list with a data frame of the fitted parameters \code{out$par},
-#'   their percentage standard errors \code{out$par.se}, the model fit object
-#'   \code{out$fit}, a dataframe containing the TACs of the data
-#'   \code{out$tacs}, a dataframe containing the fitted values
-#'   \code{out$fitvals}, the blood input data frame after time shifting
-#'   \code{input}, a vector of the weights \code{out$weights}, the inpshift
-#'   value used \code{inpshift}, the specified vB value \code{out$vB}, and the
-#'   specified tstarIncludedFrames value \code{out$tstarIncludedFrames}.
+#' @return A list with a data frame of the fitted parameters \code{out$par},,
+#'   their percentage standard errors (scaled so that 1 represents 100\%)
+#'   \code{out$par.se}, the model fit object \code{out$fit}, a dataframe
+#'   containing the TACs of the data \code{out$tacs}, a dataframe containing the
+#'   fitted values \code{out$fitvals}, the blood input data frame after time
+#'   shifting \code{input}, a vector of the weights \code{out$weights}, the
+#'   inpshift value used \code{inpshift}, the specified vB value \code{out$vB},
+#'   and the specified tstarIncludedFrames value \code{out$tstarIncludedFrames}.
 #'
 #' @examples
 #'
@@ -55,7 +63,7 @@
 #'   t_parentfrac = 1, parentfrac = 1
 #' )
 #'
-#' fit <- Patlakplot(t_tac, tac, input, 10, weights, inpshift = 0.1)
+#' fit <- Patlakplot(t_tac, tac, input, tstar=10, weights, inpshift = 0.1)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
 #'
 #' @references Patlak CS, Blasberg RG, Fenstermacher JD. Graphical evaluation of
@@ -155,7 +163,7 @@ Patlakplot <- function(t_tac, tac, input, tstar, weights = NULL,
 
   # Output
 
-  par <- as.data.frame(list(K = as.numeric(patlak_model$coefficients[2])))
+  par <- as.data.frame(list(Ki = as.numeric(patlak_model$coefficients[2])))
   fit <- patlak_model
 
   tacs <- data.frame(Time = t_tac, Target = tac, Target_uncor = tac_uncor) # uncorrected for blood volume
@@ -298,9 +306,9 @@ Patlak_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL,
   }
 
   frames <- length(t_tac)
-  lowroi_fit <- Patlakplot(t_tac, lowroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  medroi_fit <- Patlakplot(t_tac, medroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-  highroi_fit <- Patlakplot(t_tac, highroi, input, tstarIncludedFrames = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  lowroi_fit <- Patlakplot(t_tac, lowroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  medroi_fit <- Patlakplot(t_tac, medroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+  highroi_fit <- Patlakplot(t_tac, highroi, input, tstar = frames, inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
   low_xlimits <- c(0, tail(lowroi_fit$fitvals$Patlak_Plasma, 1))
   med_xlimits <- c(0, tail(medroi_fit$fitvals$Patlak_Plasma, 1))
@@ -322,12 +330,12 @@ Patlak_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL,
 
   r2_df <- data.frame(Frames = tstarInclFrames, Low = zeros, Medium = zeros, High = zeros)
   maxperc_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
-  K_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
+  Ki_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- Patlakplot(t_tac, lowroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    medfit <- Patlakplot(t_tac, medroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
-    highfit <- Patlakplot(t_tac, highroi, input, tstarIncludedFrames = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    lowfit <- Patlakplot(t_tac, lowroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    medfit <- Patlakplot(t_tac, medroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
+    highfit <- Patlakplot(t_tac, highroi, input, tstar = tstarInclFrames[i], inpshift = inpshift, vB = vB, frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared
@@ -337,9 +345,9 @@ Patlak_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL,
     maxperc_df$Medium[i] <- maxpercres(medfit)
     maxperc_df$High[i] <- maxpercres(highfit)
 
-    K_df$Low[i] <- lowfit$par$K
-    K_df$Medium[i] <- medfit$par$K
-    K_df$High[i] <- highfit$par$K
+    Ki_df$Low[i] <- lowfit$par$Ki
+    Ki_df$Medium[i] <- medfit$par$Ki
+    Ki_df$High[i] <- highfit$par$Ki
   }
 
   xlabel <- "Number of Included Frames"
@@ -379,12 +387,12 @@ Patlak_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL,
   tacplot <- ggplot(tacplotdf, aes(x = Time, y = Radioactivity, colour = Region)) + geom_point() + geom_line() + colScale
 
 
-  # K Plot
+  # Ki Plot
 
-  Kplotdf <- tidyr::gather(K_df, key = Region, value = K, -Frames, -Time)
-  Kplotdf$Region <- forcats::fct_rev(forcats::fct_inorder(factor(Kplotdf$Region)))
+  Kiplotdf <- tidyr::gather(Ki_df, key = Region, value = Ki, -Frames, -Time)
+  Kiplotdf$Region <- forcats::fct_rev(forcats::fct_inorder(factor(Kiplotdf$Region)))
 
-  Kplot <- ggplot(Kplotdf, aes(x = Frames, y = K, colour = Region)) + geom_point() + geom_line() + scale_x_continuous(breaks = seq(min(tstarInclFrames), max(tstarInclFrames), by = gridbreaks)) + ylab(expression(K[i])) + colScale
+  Kiplot <- ggplot(Kiplotdf, aes(x = Frames, y = Ki, colour = Region)) + geom_point() + geom_line() + scale_x_continuous(breaks = seq(min(tstarInclFrames), max(tstarInclFrames), by = gridbreaks)) + ylab(expression(K[i])) + colScale
 
 
   # Output
@@ -392,7 +400,7 @@ Patlak_tstar <- function(t_tac, lowroi, medroi, highroi, input, filename = NULL,
   linrow <- cowplot::plot_grid(low_linplot, med_linplot, high_linplot, nrow = 1)
   r2row <- cowplot::plot_grid(low_r2plot, med_r2plot, high_r2plot, nrow = 1)
   mprow <- cowplot::plot_grid(low_mpplot, med_mpplot, high_mpplot, nrow = 1)
-  outrow <- cowplot::plot_grid(tacplot, Kplot, rel_widths = c(2, 1))
+  outrow <- cowplot::plot_grid(tacplot, Kiplot, rel_widths = c(2, 1))
 
   totalplot <- cowplot::plot_grid(linrow, r2row, mprow, outrow, nrow = 4)
 

--- a/R/kinfitr_refPatlak.R
+++ b/R/kinfitr_refPatlak.R
@@ -1,30 +1,48 @@
 #' Patlak Reference Tissue Model
 #'
-#' Function to fit the Patlak Reference Tissue Model of Patlak & Blasbert (1985) to data.
+#' Function to fit the Patlak Reference Tissue Model of Patlak & Blasbert (1985)
+#' to data.
 #'
-#' @param t_tac Numeric vector of times for each frame in minutes. We use the time halfway through the frame as well as a
-#' zero. If a time zero frame is not included, it will be added.
-#' @param reftac Numeric vector of radioactivity concentrations in the reference tissue for each frame. We include zero at
-#' time zero: if not included, it is added.
-#' @param roitac Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
-#' zero: if not included, it is added.
+#' @param t_tac Numeric vector of times for each frame in minutes. We use the
+#'   time halfway through the frame as well as a zero. If a time zero frame is
+#'   not included, it will be added.
+#' @param reftac Numeric vector of radioactivity concentrations in the reference
+#'   tissue for each frame. We include zero at time zero: if not included, it is
+#'   added.
+#' @param roitac Numeric vector of radioactivity concentrations in the target
+#'   tissue for each frame. We include zero at time zero: if not included, it is
+#'   added.
 #' @param tstar The t* specification for regression. If tstar_type="frames",
-#' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames
-#' with midpoints later than this time are included. This value can be estimated using \code{refPatlak_tstar}.
-#' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
-#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
-#' @param weights Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:
-#' if not included, it is added. If not specified, uniform weights will be used.
+#'   this is the number of frames from the end to include (e.g., 10 means last
+#'   10 frames). If tstar_type="time", this is the time point (in minutes) after
+#'   which all frames with midpoints later than this time are included. This
+#'   value can be estimated using \code{refPatlak_tstar}.
+#' @param tstar_type Either "frames" (default) or "time", specifying how to
+#'   interpret tstar.
+#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"'
+#'   instead.
+#' @param weights Optional. Numeric vector of the weights assigned to each frame
+#'   in the fitting. We include zero at time zero: if not included, it is added.
+#'   If not specified, uniform weights will be used.
 #' @param dur Optional. Numeric vector of the time durations of the frames. If
-#' not included, the integrals will be calculated using trapezoidal integration.
-#' @param frameStartEnd Optional: This allows one to specify the beginning and final frame to use for modelling, e.g. c(1,20).
-#' This can be used to assess time stability for example.
-#' @param timeStartEnd Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.
+#'   not included, the integrals will be calculated using trapezoidal
+#'   integration.
+#' @param frameStartEnd Optional: This allows one to specify the beginning and
+#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess
+#'   time stability for example.
+#' @param timeStartEnd Optional. This allows one to specify the beginning and
+#'   end time point instead of defining the frame numbers using frameStartEnd.
+#'   This function will restrict the model to all time frames whose t_tac is
+#'   between the values, i.e. c(0,5) will select all frames with midtimes during
+#'   the first 5 minutes.
 #'
-#' @return A list with a data frame of the fitted parameters \code{out$par}, the model fit object \code{out$fit}, a dataframe
-#' containing the TACs of the data \code{out$tacs}, a dataframe containing the TACs of the fitted values \code{out$fitvals},
-#' a vector of the weights \code{out$weights}, and the specified tstarIncludedFrames value \code{out$tstarIncludedFrames}
+#' @return A list with a data frame of the fitted parameters \code{out$par},
+#'   their percentage standard errors (scaled so that 1 represents 100\%)
+#'   \code{out$par.se}, the model fit object \code{out$fit}, a dataframe
+#'   containing the TACs of the data \code{out$tacs}, a dataframe containing the
+#'   TACs of the fitted values \code{out$fitvals}, a vector of the weights
+#'   \code{out$weights}, and the specified tstarIncludedFrames value
+#'   \code{out$tstarIncludedFrames}
 #'
 #' @examples
 #' # Note: Reference region models, and irreversible binding models, should not
@@ -37,10 +55,12 @@
 #' roitac <- pbr28$tacs[[2]]$STR
 #' weights <- pbr28$tacs[[2]]$Weights
 #'
-#' fit <- refPatlak(t_tac, reftac, roitac, tstarIncludedFrames = 10, weights = weights)
+#' fit <- refPatlak(t_tac, reftac, roitac, tstar = 10, weights = weights)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
 #'
-#' @references Patlak CS, Blasberg RG. Graphical evaluation of blood-to-brain transfer constants from multiple-time uptake data. Generalizations. Journal of Cerebral Blood Flow & Metabolism. 1985 Dec 1;5(4):584-90.
+#' @references Patlak CS, Blasberg RG. Graphical evaluation of blood-to-brain
+#'   transfer constants from multiple-time uptake data. Generalizations. Journal
+#'   of Cerebral Blood Flow & Metabolism. 1985 Dec 1;5(4):584-90.
 #'
 #' @export
 
@@ -121,7 +141,12 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
 
   # Output
 
-  par <- as.data.frame(list(K = as.numeric(patlak_model$coefficients[2])))
+  par <- as.data.frame(list(Kiref = as.numeric(patlak_model$coefficients[2])))
+
+  par.se <- par
+  names(par.se) <- paste0(names(par.se), ".se")
+  par.se$Kiref.se <- get_se(patlak_model, "patlak_equil_ref")
+
   fit <- patlak_model
 
   tacs <- data.frame(Time = t_tac, Reference = reftac, Target = roitac )
@@ -133,8 +158,9 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
   fitvals <- data.frame(Patlak_ROI = patlak_roi, Patlak_Ref = patlak_ref)
 
   out <- list(
-    par = par, fit = fit, tacs = tacs, fitvals = fitvals, weights = weights,
-    tstarIncludedFrames = tstarIncludedFrames, model = "refPatlak"
+    par = par, par.se = par.se, fit = fit, tacs = tacs, fitvals = fitvals,
+    weights = weights, tstarIncludedFrames = tstarIncludedFrames,
+    model = "refPatlak"
   )
 
   class(out) <- c("refPatlak", "kinfit")
@@ -162,7 +188,7 @@ refPatlak <- function(t_tac, reftac, roitac, tstar, weights = NULL,
 #' roitac <- pbr28$tacs[[2]]$STR
 #' weights <- pbr28$tacs[[2]]$Weights
 #'
-#' fit <- refPatlak(t_tac, reftac, roitac, tstarIncludedFrames = 10, weights = weights)
+#' fit <- refPatlak(t_tac, reftac, roitac, tstar = 10, weights = weights)
 #'
 #' plot_refPatlakfit(fit)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
@@ -270,9 +296,9 @@ refPatlak_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = N
   k_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- refPatlak(t_tac, reftac, lowroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    medfit <- refPatlak(t_tac, reftac, medroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    highfit <- refPatlak(t_tac, reftac, highroi, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    lowfit <- refPatlak(t_tac, reftac, lowroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    medfit <- refPatlak(t_tac, reftac, medroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    highfit <- refPatlak(t_tac, reftac, highroi, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared
@@ -282,9 +308,9 @@ refPatlak_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = N
     maxperc_df$Medium[i] <- maxpercres(medfit)
     maxperc_df$High[i] <- maxpercres(highfit)
 
-    k_df$Low[i] <- lowfit$par$K
-    k_df$Medium[i] <- medfit$par$K
-    k_df$High[i] <- highfit$par$K
+    k_df$Low[i] <- lowfit$par$Kiref
+    k_df$Medium[i] <- medfit$par$Kiref
+    k_df$High[i] <- highfit$par$Kiref
   }
 
   xlabel <- "Number of Included Frames"
@@ -322,12 +348,12 @@ refPatlak_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, filename = N
   tacplot <- ggplot(tacplotdf, aes(x = Time, y = Radioactivity, colour = Region)) + geom_point() + geom_line() + colScale
 
 
-  # K Plot
+  # Kiref Plot
 
-  kplotdf <- tidyr::gather(k_df, key = Region, value = K, -Frames, -Time)
+  kplotdf <- tidyr::gather(k_df, key = Region, value = Kiref, -Frames, -Time)
   kplotdf$Region <- forcats::fct_rev(forcats::fct_inorder(factor(kplotdf$Region)))
 
-  kplot <- ggplot(kplotdf, aes(x = Frames, y = K, colour = Region)) + geom_point() + geom_line() + scale_x_continuous(breaks = seq(min(tstarInclFrames), max(tstarInclFrames), by = gridbreaks)) + ylab(expression(K[i])) + colScale
+  kplot <- ggplot(kplotdf, aes(x = Frames, y = Kiref, colour = Region)) + geom_point() + geom_line() + scale_x_continuous(breaks = seq(min(tstarInclFrames), max(tstarInclFrames), by = gridbreaks)) + ylab(expression(K[i]^{ref})) + colScale
 
 
   # Output

--- a/R/kinfitr_reflogan.R
+++ b/R/kinfitr_reflogan.R
@@ -1,34 +1,54 @@
 #' Non-Invasive Logan Plot
 #'
-#' Function to fit the non-invasive Logan plot model of Logan et al. (1996) to data.
+#' Function to fit the non-invasive Logan plot model of Logan et al. (1996) to
+#' data.
 #'
-#' @param t_tac Numeric vector of times for each frame in minutes. We use the time halfway through the frame as well as a
-#' zero. If a time zero frame is not included, it will be added.
-#' @param reftac Numeric vector of radioactivity concentrations in the reference tissue for each frame. We include zero at
-#' time zero: if not included, it is added.
-#' @param roitac Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
-#' zero: if not included, it is added.
-#' @param k2prime Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
-#' obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.
+#' @param t_tac Numeric vector of times for each frame in minutes. We use the
+#'   time halfway through the frame as well as a zero. If a time zero frame is
+#'   not included, it will be added.
+#' @param reftac Numeric vector of radioactivity concentrations in the reference
+#'   tissue for each frame. We include zero at time zero: if not included, it is
+#'   added.
+#' @param roitac Numeric vector of radioactivity concentrations in the target
+#'   tissue for each frame. We include zero at time zero: if not included, it is
+#'   added.
+#' @param k2prime Value of k2prime to be used for the fitting, i.e. the average
+#'   tissue-to-plasma clearance rate. This can be obtained from another model,
+#'   or set at a specified value. If using SRTM to estimate this value, it is
+#'   equal to k2 / R1.
 #' @param tstar The t* specification for regression. If tstar_type="frames",
-#' this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-#' If tstar_type="time", this is the time point (in minutes) after which all frames
-#' with midpoints later than this time are included. This value can be estimated using \code{refLogan_tstar}.
-#' @param tstar_type Either "frames" (default) or "time", specifying how to interpret tstar.
-#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.
-#' @param weights Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:
-#' if not included, it is added. If not specified, uniform weights will be used.
+#'   this is the number of frames from the end to include (e.g., 10 means last
+#'   10 frames). If tstar_type="time", this is the time point (in minutes) after
+#'   which all frames with midpoints later than this time are included. This
+#'   value can be estimated using \code{refLogan_tstar}.
+#' @param tstar_type Either "frames" (default) or "time", specifying how to
+#'   interpret tstar.
+#' @param tstarIncludedFrames Deprecated. Use 'tstar' with 'tstar_type="frames"'
+#'   instead.
+#' @param weights Optional. Numeric vector of the weights assigned to each frame
+#'   in the fitting. We include zero at time zero: if not included, it is added.
+#'   If not specified, uniform weights will be used.
 #' @param dur Optional. Numeric vector of the time durations of the frames. If
-#' not included, the integrals will be calculated using trapezoidal integration.
-#' @param frameStartEnd Optional: This allows one to specify the beginning and final frame to use for modelling, e.g. c(1,20).
-#' This can be used to assess time stability for example.
-#' @param timeStartEnd Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.
+#'   not included, the integrals will be calculated using trapezoidal
+#'   integration.
+#' @param frameStartEnd Optional: This allows one to specify the beginning and
+#'   final frame to use for modelling, e.g. c(1,20). This can be used to assess
+#'   time stability for example.
+#' @param timeStartEnd Optional. This allows one to specify the beginning and
+#'   end time point instead of defining the frame numbers using frameStartEnd.
+#'   This function will restrict the model to all time frames whose t_tac is
+#'   between the values, i.e. c(0,5) will select all frames with midtimes during
+#'   the first 5 minutes.
 
 #'
-#' @return A list with a data frame of the fitted parameters \code{out$par}, the model fit object \code{out$fit}, a dataframe
-#' containing the TACs of the data \code{out$tacs}, a dataframe containing the TACs of the fitted values \code{out$fitvals},
-#' a vector of the weights \code{out$weights}, the specified k2prime value \code{out$k2prime}, and the specified
-#' tstarIncludedFrames value \code{out$tstarIncludedFrames}
+#' @return A list with a data frame of the fitted parameters \code{out$par},
+#'   their percentage standard errors (scaled so that 1 represents 100\%)
+#'   \code{out$par.se}, the
+#'   model fit object \code{out$fit}, a dataframe containing the TACs of the
+#'   data \code{out$tacs}, a dataframe containing the TACs of the fitted values
+#'   \code{out$fitvals}, a vector of the weights \code{out$weights}, the
+#'   specified k2prime value \code{out$k2prime}, and the specified
+#'   tstarIncludedFrames value \code{out$tstarIncludedFrames}
 #'
 #' @examples
 #'
@@ -39,10 +59,13 @@
 #' roitac <- simref$tacs[[2]]$ROI1
 #' weights <- simref$tacs[[2]]$Weights
 #'
-#' fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 15, weights = weights)
+#' fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 15, weights = weights)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
 #'
-#' @references Logan J, Fowler JS, Volkow ND, Wang GJ, Ding YS, Alexoff DL. Distribution volume ratios without blood sampling from graphical analysis of PET data. Journal of Cerebral Blood Flow & Metabolism. 1996 Sep 1;16(5):834-40.
+#' @references Logan J, Fowler JS, Volkow ND, Wang GJ, Ding YS, Alexoff DL.
+#'   Distribution volume ratios without blood sampling from graphical analysis
+#'   of PET data. Journal of Cerebral Blood Flow & Metabolism. 1996 Sep
+#'   1;16(5):834-40.
 #'
 #' @export
 
@@ -124,6 +147,11 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
   # Output
 
   par <- as.data.frame(list(bp = as.numeric(logan_model$coefficients[2]) - 1))
+
+  par.se <- par
+  names(par.se) <- paste0(names(par.se), ".se")
+  par.se$bp.se <- get_se(logan_model, "logan_equil_ref - 1)")
+
   fit <- logan_model
 
   tacs <- data.frame(Time = t_tac, Reference = reftac, Target = roitac)
@@ -133,8 +161,8 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
   fitvals <- data.frame(Logan_ROI = logan_roi, Logan_Ref = logan_ref)
 
   out <- list(
-    par = par, fit = fit, tacs = tacs, fitvals = fitvals,
-    weights = weights, k2prime = k2prime,
+    par = par, par.se = par.se, fit = fit, tacs = tacs,
+    fitvals = fitvals, weights = weights, k2prime = k2prime,
     tstarIncludedFrames = tstarIncludedFrames, model = "refLogan"
   )
 
@@ -160,7 +188,7 @@ refLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
 #' roitac <- simref$tacs[[2]]$ROI1
 #' weights <- simref$tacs[[2]]$Weights
 #'
-#' fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+#' fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 #'
 #' plot_refLoganfit(fit)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
@@ -279,9 +307,9 @@ refLogan_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, file
   bp_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- refLogan(t_tac, reftac, lowroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    medfit <- refLogan(t_tac, reftac, medroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    highfit <- refLogan(t_tac, reftac, highroi, k2prime = k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    lowfit <- refLogan(t_tac, reftac, lowroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    medfit <- refLogan(t_tac, reftac, medroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    highfit <- refLogan(t_tac, reftac, highroi, k2prime = k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kinfitr_refmllogan.R
+++ b/R/kinfitr_refmllogan.R
@@ -37,7 +37,7 @@
 #' roitac <- simref$tacs[[2]]$ROI1
 #' weights <- simref$tacs[[2]]$Weights
 #'
-#' fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+#' fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
 #'
 #' @references Turkheimer FE, Aston JA, Banati RB, Riddell C, Cunningham VJ. A linear wavelet filter for parametric imaging with dynamic PET. IEEE transactions on medical imaging. 2003 Mar;22(3):289-301.
@@ -173,7 +173,7 @@ refmlLogan <- function(t_tac, reftac, roitac, k2prime, tstar, weights = NULL,
 #' roitac <- simref$tacs[[2]]$ROI1
 #' weights <- simref$tacs[[2]]$Weights
 #'
-#' fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+#' fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 #'
 #' plot_refmlLoganfit(fit)
 #' @author Granville J Matheson, \email{mathesong@@gmail.com}
@@ -279,9 +279,9 @@ refmlLogan_tstar <- function(t_tac, reftac, lowroi, medroi, highroi, k2prime, fi
   bp_df <- data.frame(Frames = tstarInclFrames, Time = t_tac[ tstarInclFrames ], Low = zeros, Medium = zeros, High = zeros)
 
   for (i in 1:length(tstarInclFrames)) {
-    lowfit <- refmlLogan(t_tac, reftac, lowroi, k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    medfit <- refmlLogan(t_tac, reftac, medroi, k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
-    highfit <- refmlLogan(t_tac, reftac, highroi, k2prime, tstarIncludedFrames = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    lowfit <- refmlLogan(t_tac, reftac, lowroi, k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    medfit <- refmlLogan(t_tac, reftac, medroi, k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
+    highfit <- refmlLogan(t_tac, reftac, highroi, k2prime, tstar = tstarInclFrames[i], frameStartEnd = frameStartEnd)
 
     r2_df$Low[i] <- summary(lowfit$fit)$r.squared
     r2_df$Medium[i] <- summary(medfit$fit)$r.squared

--- a/R/kiniftr.R
+++ b/R/kiniftr.R
@@ -7,20 +7,20 @@ NULL
 
 # Suppress R CMD check notes about NSE variables used in dplyr/ggplot2 functions
 utils::globalVariables(c(
-  ".", ".x", "AIF", "AIFmodel", "BP", "BPR", "Blood", "Data", "Equilibrium", 
-  "Exclude", "Fitted", "Frames", "High", "K", "Label", "Logan_Plasma", 
-  "Logan_ROI", "Logan_ref", "Logan_roi", "Low", "Measurement", "Medium", 
-  "Method", "Outcome", "ParentFraction", "Patlak_Plasma", "Patlak_ROI", 
-  "Patlak_ref", "Patlak_roi", "Plasma", "Pred", "RSS", "RSSw", "Radioactivity", 
-  "Region", "TAC", "Term1_DV", "Time", "Unit_AIF", "Unit_time", "Value", 
-  "Vnd", "Vt", "Weights", "acq", "activity", "activity_1ex", "activity_2ex", 
-  "all_of", "attribute", "data", "dotsize", "dur", "everything", "extension", 
-  "filedata", "fit", "inpshift", "jsondata", "keep", "lag", "lead", "log_RSS", 
-  "measplasma", "measurement", "metabolite_parent_fraction", "parentFraction", 
-  "path", "path_absolute", "path_relative", "plasma_radioactivity", 
-  "plasma_uncor", "prop_success", "rec", "recording", "run", "sampleDuration", 
-  "sampleStartTime", "ses", "start", "starts_with", "success", "tactimes", 
-  "task", "time", "trc", "tsvdata", "update_blooddata_bids", "value", 
-  "whole_blood_radioactivity", "ROI.fitted", "ROI.measured", "ROI_measured", 
-  "Reference", "Target.fitted", "Target.measured", "Measure"
+  ".", ".x", "AIF", "AIFmodel", "BP", "BPR", "Blood", "Data", "Equilibrium",
+  "Exclude", "Fitted", "Frames", "High", "K", "Label", "Logan_Plasma",
+  "Logan_ROI", "Logan_ref", "Logan_roi", "Low", "Measurement", "Medium",
+  "Method", "Outcome", "ParentFraction", "Patlak_Plasma", "Patlak_ROI",
+  "Patlak_ref", "Patlak_roi", "Plasma", "Pred", "RSS", "RSSw", "Radioactivity",
+  "Region", "TAC", "Term1_DV", "Time", "Unit_AIF", "Unit_time", "Value",
+  "Vnd", "Vt", "Weights", "acq", "activity", "activity_1ex", "activity_2ex",
+  "all_of", "attribute", "data", "dotsize", "dur", "everything", "extension",
+  "filedata", "fit", "inpshift", "jsondata", "keep", "lag", "lead", "log_RSS",
+  "measplasma", "measurement", "metabolite_parent_fraction", "parentFraction",
+  "path", "path_absolute", "path_relative", "plasma_radioactivity",
+  "plasma_uncor", "prop_success", "rec", "recording", "run", "sampleDuration",
+  "sampleStartTime", "ses", "start", "starts_with", "success", "tactimes",
+  "task", "time", "trc", "tsvdata", "update_blooddata_bids", "value",
+  "whole_blood_radioactivity", "ROI.fitted", "ROI.measured", "ROI_measured",
+  "Reference", "Target.fitted", "Target.measured", "Measure", "Ki", "Kiref"
 ))

--- a/man/Patlakplot.Rd
+++ b/man/Patlakplot.Rd
@@ -32,9 +32,10 @@ concentrations over time.  This can be generated using the
 \code{blood_interp} function.}
 
 \item{tstar}{The t* specification for regression. If tstar_type="frames",
-this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames
-with midpoints later than this time are included. This value can be estimated using \code{Patlak_tstar}.}
+this is the number of frames from the end to include (e.g., 10 means last
+10 frames). If tstar_type="time", this is the time point (in minutes) after
+which all frames with midpoints later than this time are included. This
+value can be estimated using \code{Patlak_tstar}.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame
 in the fitting. We include zero at time zero: if not included, it is added.
@@ -50,23 +51,30 @@ prior to parameter estimation using the following equation: \deqn{C_{T}(t)
 = \frac{C_{Measured}(t) - vB\times C_{B}(t)}{1-vB}}}
 
 \item{frameStartEnd}{Optional: This allows one to specify the beginning and
-final frame to use for modelling, e.g. c(1,20). This can be used to assess time stability for example.}
+final frame to use for modelling, e.g. c(1,20). This can be used to assess
+time stability for example.}
 
-\item{timeStartEnd}{Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.}
+\item{timeStartEnd}{Optional. This allows one to specify the beginning and
+end time point instead of defining the frame numbers using frameStartEnd.
+This function will restrict the model to all time frames whose t_tac is
+between the values, i.e. c(0,5) will select all frames with midtimes during
+the first 5 minutes.}
 
-\item{tstar_type}{Either "frames" (default) or "time", specifying how to interpret tstar.}
+\item{tstar_type}{Either "frames" (default) or "time", specifying how to
+interpret tstar.}
 
-\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.}
+\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"'
+instead.}
 }
 \value{
-A list with a data frame of the fitted parameters \code{out$par},
-  their percentage standard errors \code{out$par.se}, the model fit object
-  \code{out$fit}, a dataframe containing the TACs of the data
-  \code{out$tacs}, a dataframe containing the fitted values
-  \code{out$fitvals}, the blood input data frame after time shifting
-  \code{input}, a vector of the weights \code{out$weights}, the inpshift
-  value used \code{inpshift}, the specified vB value \code{out$vB}, and the
-  specified tstarIncludedFrames value \code{out$tstarIncludedFrames}.
+A list with a data frame of the fitted parameters \code{out$par},,
+  their percentage standard errors (scaled so that 1 represents 100\%)
+  \code{out$par.se}, the model fit object \code{out$fit}, a dataframe
+  containing the TACs of the data \code{out$tacs}, a dataframe containing the
+  fitted values \code{out$fitvals}, the blood input data frame after time
+  shifting \code{input}, a vector of the weights \code{out$weights}, the
+  inpshift value used \code{inpshift}, the specified vB value \code{out$vB},
+  and the specified tstarIncludedFrames value \code{out$tstarIncludedFrames}.
 }
 \description{
 Function to fit the Patlak Plot of of Patlak et al (1983) to data.
@@ -85,7 +93,7 @@ input <- blood_interp(
   t_parentfrac = 1, parentfrac = 1
 )
 
-fit <- Patlakplot(t_tac, tac, input, 10, weights, inpshift = 0.1)
+fit <- Patlakplot(t_tac, tac, input, tstar=10, weights, inpshift = 0.1)
 }
 \references{
 Patlak CS, Blasberg RG, Fenstermacher JD. Graphical evaluation of

--- a/man/maxpercres.Rd
+++ b/man/maxpercres.Rd
@@ -29,7 +29,7 @@ reftac <- pbr28$tacs[[2]]$CBL
 roitac <- pbr28$tacs[[2]]$STR
 weights <- pbr28$tacs[[2]]$Weights
 
-refloganout <- refLogan(t_tac, reftac, roitac, 0.1, tstarIncludedFrames = 9)
+refloganout <- refLogan(t_tac, reftac, roitac, 0.1, tstar = 9)
 
 maxpercres(refloganout)
 }

--- a/man/mrtm1.Rd
+++ b/man/mrtm1.Rd
@@ -30,18 +30,19 @@ added.}
 tissue for each frame. We include zero at time zero: if not included, it is
 added.}
 
-\item{tstar}{Optional. The t* specification for regression. If tstar_type="frames",
-this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames
-with midpoints later than this time are included. This value can be estimated using \code{mrtm1_tstar}.
-Note that this t* differs from that of the non-invasive Logan plot (which is the point at which
-pseudo-equilibrium is reached). Rather, with MRTM1 and MRTM2, all frames
-can be used provided that the kinetics in the target tissue can be
-described by a one tissue compartment (1TC) model (like SRTM). If this is
-not the case, a t* is required. If the number of included frames is greater
-than the number of frames minus 2, then the par output will also include R1
-and k2 values. These parameters are only applicable if 1TC dynamics can be
-assumed.}
+\item{tstar}{Optional. The t* specification for regression. If
+tstar_type="frames", this is the number of frames from the end to include
+(e.g., 10 means last 10 frames). If tstar_type="time", this is the time
+point (in minutes) after which all frames with midpoints later than this
+time are included. This value can be estimated using \code{mrtm1_tstar}.
+Note that this t* differs from that of the non-invasive Logan plot (which
+is the point at which pseudo-equilibrium is reached). Rather, with MRTM1
+and MRTM2, all frames can be used provided that the kinetics in the target
+tissue can be described by a one tissue compartment (1TC) model (like
+SRTM). If this is not the case, a t* is required. If the number of included
+frames is greater than the number of frames minus 2, then the par output
+will also include R1 and k2 values. These parameters are only applicable if
+1TC dynamics can be assumed.}
 
 \item{weights}{Optional. Numeric vector of the weights assigned to each frame
 in the fitting. We include zero at time zero: if not included, it is added.
@@ -52,13 +53,20 @@ not included, the integrals will be calculated using trapezoidal
 integration.}
 
 \item{frameStartEnd}{Optional: This allows one to specify the beginning and
-final frame to use for modelling, e.g. c(1,20). This can be used to assess time stability for example.}
+final frame to use for modelling, e.g. c(1,20). This can be used to assess
+time stability for example.}
 
-\item{timeStartEnd}{Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.}
+\item{timeStartEnd}{Optional. This allows one to specify the beginning and
+end time point instead of defining the frame numbers using frameStartEnd.
+This function will restrict the model to all time frames whose t_tac is
+between the values, i.e. c(0,5) will select all frames with midtimes during
+the first 5 minutes.}
 
-\item{tstar_type}{Either "frames" (default) or "time", specifying how to interpret tstar.}
+\item{tstar_type}{Either "frames" (default) or "time", specifying how to
+interpret tstar.}
 
-\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.}
+\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"'
+instead.}
 }
 \value{
 A list with a data frame of the fitted parameters \code{out$par},

--- a/man/plot_refLoganfit.Rd
+++ b/man/plot_refLoganfit.Rd
@@ -25,7 +25,7 @@ reftac <- simref$tacs[[2]]$Reference
 roitac <- simref$tacs[[2]]$ROI1
 weights <- simref$tacs[[2]]$Weights
 
-fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 
 plot_refLoganfit(fit)
 }

--- a/man/plot_refPatlakfit.Rd
+++ b/man/plot_refPatlakfit.Rd
@@ -28,7 +28,7 @@ reftac <- pbr28$tacs[[2]]$CBL
 roitac <- pbr28$tacs[[2]]$STR
 weights <- pbr28$tacs[[2]]$Weights
 
-fit <- refPatlak(t_tac, reftac, roitac, tstarIncludedFrames = 10, weights = weights)
+fit <- refPatlak(t_tac, reftac, roitac, tstar = 10, weights = weights)
 
 plot_refPatlakfit(fit)
 }

--- a/man/plot_refmlLoganfit.Rd
+++ b/man/plot_refmlLoganfit.Rd
@@ -25,7 +25,7 @@ reftac <- simref$tacs[[2]]$Reference
 roitac <- simref$tacs[[2]]$ROI1
 weights <- simref$tacs[[2]]$Weights
 
-fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 
 plot_refmlLoganfit(fit)
 }

--- a/man/refLogan.Rd
+++ b/man/refLogan.Rd
@@ -19,46 +19,66 @@ refLogan(
 )
 }
 \arguments{
-\item{t_tac}{Numeric vector of times for each frame in minutes. We use the time halfway through the frame as well as a
-zero. If a time zero frame is not included, it will be added.}
+\item{t_tac}{Numeric vector of times for each frame in minutes. We use the
+time halfway through the frame as well as a zero. If a time zero frame is
+not included, it will be added.}
 
-\item{reftac}{Numeric vector of radioactivity concentrations in the reference tissue for each frame. We include zero at
-time zero: if not included, it is added.}
+\item{reftac}{Numeric vector of radioactivity concentrations in the reference
+tissue for each frame. We include zero at time zero: if not included, it is
+added.}
 
-\item{roitac}{Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
-zero: if not included, it is added.}
+\item{roitac}{Numeric vector of radioactivity concentrations in the target
+tissue for each frame. We include zero at time zero: if not included, it is
+added.}
 
-\item{k2prime}{Value of k2prime to be used for the fitting, i.e. the average tissue-to-plasma clearance rate. This can be
-obtained from another model, or set at a specified value. If using SRTM to estimate this value, it is equal to k2 / R1.}
+\item{k2prime}{Value of k2prime to be used for the fitting, i.e. the average
+tissue-to-plasma clearance rate. This can be obtained from another model,
+or set at a specified value. If using SRTM to estimate this value, it is
+equal to k2 / R1.}
 
 \item{tstar}{The t* specification for regression. If tstar_type="frames",
-this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames
-with midpoints later than this time are included. This value can be estimated using \code{refLogan_tstar}.}
+this is the number of frames from the end to include (e.g., 10 means last
+10 frames). If tstar_type="time", this is the time point (in minutes) after
+which all frames with midpoints later than this time are included. This
+value can be estimated using \code{refLogan_tstar}.}
 
-\item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:
-if not included, it is added. If not specified, uniform weights will be used.}
+\item{weights}{Optional. Numeric vector of the weights assigned to each frame
+in the fitting. We include zero at time zero: if not included, it is added.
+If not specified, uniform weights will be used.}
 
 \item{dur}{Optional. Numeric vector of the time durations of the frames. If
-not included, the integrals will be calculated using trapezoidal integration.}
+not included, the integrals will be calculated using trapezoidal
+integration.}
 
-\item{frameStartEnd}{Optional: This allows one to specify the beginning and final frame to use for modelling, e.g. c(1,20).
-This can be used to assess time stability for example.}
+\item{frameStartEnd}{Optional: This allows one to specify the beginning and
+final frame to use for modelling, e.g. c(1,20). This can be used to assess
+time stability for example.}
 
-\item{timeStartEnd}{Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.}
+\item{timeStartEnd}{Optional. This allows one to specify the beginning and
+end time point instead of defining the frame numbers using frameStartEnd.
+This function will restrict the model to all time frames whose t_tac is
+between the values, i.e. c(0,5) will select all frames with midtimes during
+the first 5 minutes.}
 
-\item{tstar_type}{Either "frames" (default) or "time", specifying how to interpret tstar.}
+\item{tstar_type}{Either "frames" (default) or "time", specifying how to
+interpret tstar.}
 
-\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.}
+\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"'
+instead.}
 }
 \value{
-A list with a data frame of the fitted parameters \code{out$par}, the model fit object \code{out$fit}, a dataframe
-containing the TACs of the data \code{out$tacs}, a dataframe containing the TACs of the fitted values \code{out$fitvals},
-a vector of the weights \code{out$weights}, the specified k2prime value \code{out$k2prime}, and the specified
-tstarIncludedFrames value \code{out$tstarIncludedFrames}
+A list with a data frame of the fitted parameters \code{out$par},
+  their percentage standard errors (scaled so that 1 represents 100\%)
+  \code{out$par.se}, the
+  model fit object \code{out$fit}, a dataframe containing the TACs of the
+  data \code{out$tacs}, a dataframe containing the TACs of the fitted values
+  \code{out$fitvals}, a vector of the weights \code{out$weights}, the
+  specified k2prime value \code{out$k2prime}, and the specified
+  tstarIncludedFrames value \code{out$tstarIncludedFrames}
 }
 \description{
-Function to fit the non-invasive Logan plot model of Logan et al. (1996) to data.
+Function to fit the non-invasive Logan plot model of Logan et al. (1996) to
+data.
 }
 \examples{
 
@@ -69,10 +89,13 @@ reftac <- simref$tacs[[2]]$Reference
 roitac <- simref$tacs[[2]]$ROI1
 weights <- simref$tacs[[2]]$Weights
 
-fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 15, weights = weights)
+fit <- refLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 15, weights = weights)
 }
 \references{
-Logan J, Fowler JS, Volkow ND, Wang GJ, Ding YS, Alexoff DL. Distribution volume ratios without blood sampling from graphical analysis of PET data. Journal of Cerebral Blood Flow & Metabolism. 1996 Sep 1;16(5):834-40.
+Logan J, Fowler JS, Volkow ND, Wang GJ, Ding YS, Alexoff DL.
+  Distribution volume ratios without blood sampling from graphical analysis
+  of PET data. Journal of Cerebral Blood Flow & Metabolism. 1996 Sep
+  1;16(5):834-40.
 }
 \author{
 Granville J Matheson, \email{mathesong@gmail.com}

--- a/man/refPatlak.Rd
+++ b/man/refPatlak.Rd
@@ -18,42 +18,60 @@ refPatlak(
 )
 }
 \arguments{
-\item{t_tac}{Numeric vector of times for each frame in minutes. We use the time halfway through the frame as well as a
-zero. If a time zero frame is not included, it will be added.}
+\item{t_tac}{Numeric vector of times for each frame in minutes. We use the
+time halfway through the frame as well as a zero. If a time zero frame is
+not included, it will be added.}
 
-\item{reftac}{Numeric vector of radioactivity concentrations in the reference tissue for each frame. We include zero at
-time zero: if not included, it is added.}
+\item{reftac}{Numeric vector of radioactivity concentrations in the reference
+tissue for each frame. We include zero at time zero: if not included, it is
+added.}
 
-\item{roitac}{Numeric vector of radioactivity concentrations in the target tissue for each frame. We include zero at time
-zero: if not included, it is added.}
+\item{roitac}{Numeric vector of radioactivity concentrations in the target
+tissue for each frame. We include zero at time zero: if not included, it is
+added.}
 
 \item{tstar}{The t* specification for regression. If tstar_type="frames",
-this is the number of frames from the end to include (e.g., 10 means last 10 frames).
-If tstar_type="time", this is the time point (in minutes) after which all frames
-with midpoints later than this time are included. This value can be estimated using \code{refPatlak_tstar}.}
+this is the number of frames from the end to include (e.g., 10 means last
+10 frames). If tstar_type="time", this is the time point (in minutes) after
+which all frames with midpoints later than this time are included. This
+value can be estimated using \code{refPatlak_tstar}.}
 
-\item{weights}{Optional. Numeric vector of the weights assigned to each frame in the fitting. We include zero at time zero:
-if not included, it is added. If not specified, uniform weights will be used.}
+\item{weights}{Optional. Numeric vector of the weights assigned to each frame
+in the fitting. We include zero at time zero: if not included, it is added.
+If not specified, uniform weights will be used.}
 
 \item{dur}{Optional. Numeric vector of the time durations of the frames. If
-not included, the integrals will be calculated using trapezoidal integration.}
+not included, the integrals will be calculated using trapezoidal
+integration.}
 
-\item{frameStartEnd}{Optional: This allows one to specify the beginning and final frame to use for modelling, e.g. c(1,20).
-This can be used to assess time stability for example.}
+\item{frameStartEnd}{Optional: This allows one to specify the beginning and
+final frame to use for modelling, e.g. c(1,20). This can be used to assess
+time stability for example.}
 
-\item{timeStartEnd}{Optional. This allows one to specify the beginning and end time point instead of defining the frame numbers using frameStartEnd. This function will restrict the model to all time frames whose t_tac is between the values, i.e. c(0,5) will select all frames with midtimes during the first 5 minutes.}
+\item{timeStartEnd}{Optional. This allows one to specify the beginning and
+end time point instead of defining the frame numbers using frameStartEnd.
+This function will restrict the model to all time frames whose t_tac is
+between the values, i.e. c(0,5) will select all frames with midtimes during
+the first 5 minutes.}
 
-\item{tstar_type}{Either "frames" (default) or "time", specifying how to interpret tstar.}
+\item{tstar_type}{Either "frames" (default) or "time", specifying how to
+interpret tstar.}
 
-\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"' instead.}
+\item{tstarIncludedFrames}{Deprecated. Use 'tstar' with 'tstar_type="frames"'
+instead.}
 }
 \value{
-A list with a data frame of the fitted parameters \code{out$par}, the model fit object \code{out$fit}, a dataframe
-containing the TACs of the data \code{out$tacs}, a dataframe containing the TACs of the fitted values \code{out$fitvals},
-a vector of the weights \code{out$weights}, and the specified tstarIncludedFrames value \code{out$tstarIncludedFrames}
+A list with a data frame of the fitted parameters \code{out$par},
+  their percentage standard errors (scaled so that 1 represents 100\%)
+  \code{out$par.se}, the model fit object \code{out$fit}, a dataframe
+  containing the TACs of the data \code{out$tacs}, a dataframe containing the
+  TACs of the fitted values \code{out$fitvals}, a vector of the weights
+  \code{out$weights}, and the specified tstarIncludedFrames value
+  \code{out$tstarIncludedFrames}
 }
 \description{
-Function to fit the Patlak Reference Tissue Model of Patlak & Blasbert (1985) to data.
+Function to fit the Patlak Reference Tissue Model of Patlak & Blasbert (1985)
+to data.
 }
 \examples{
 # Note: Reference region models, and irreversible binding models, should not
@@ -66,10 +84,12 @@ reftac <- pbr28$tacs[[2]]$CBL
 roitac <- pbr28$tacs[[2]]$STR
 weights <- pbr28$tacs[[2]]$Weights
 
-fit <- refPatlak(t_tac, reftac, roitac, tstarIncludedFrames = 10, weights = weights)
+fit <- refPatlak(t_tac, reftac, roitac, tstar = 10, weights = weights)
 }
 \references{
-Patlak CS, Blasberg RG. Graphical evaluation of blood-to-brain transfer constants from multiple-time uptake data. Generalizations. Journal of Cerebral Blood Flow & Metabolism. 1985 Dec 1;5(4):584-90.
+Patlak CS, Blasberg RG. Graphical evaluation of blood-to-brain
+  transfer constants from multiple-time uptake data. Generalizations. Journal
+  of Cerebral Blood Flow & Metabolism. 1985 Dec 1;5(4):584-90.
 }
 \author{
 Granville J Matheson, \email{mathesong@gmail.com}

--- a/man/refmlLogan.Rd
+++ b/man/refmlLogan.Rd
@@ -68,7 +68,7 @@ reftac <- simref$tacs[[2]]$Reference
 roitac <- simref$tacs[[2]]$ROI1
 weights <- simref$tacs[[2]]$Weights
 
-fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstarIncludedFrames = 10, weights = weights)
+fit <- refmlLogan(t_tac, reftac, roitac, k2prime = 0.1, tstar = 10, weights = weights)
 }
 \references{
 Turkheimer FE, Aston JA, Banati RB, Riddell C, Cunningham VJ. A linear wavelet filter for parametric imaging with dynamic PET. IEEE transactions on medical imaging. 2003 Mar;22(3):289-301.


### PR DESCRIPTION
SE was missing from Patlak, refPatlak and refLogan, so it's been added for PETFit.

Also, I fixed instances of tstarIncluded frames being used mostly in the tstar plotters where it would trigger the deprecation warning.