### PR TITLE
Extend blmod_splines(): monotone splines, t0 onset estimation, more weighting schemes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ Depends:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
 Imports:
     pracma,
     minpack.lm,
@@ -34,6 +33,7 @@ Imports:
     cowplot,
     car,
     mgcv,
+    scam,
     fs,
     stringr,
     segmented,
@@ -46,3 +46,4 @@ Suggests:
     testthat,
     rmarkdown,
     covr
+Config/roxygen2/version: 8.0.0

--- a/R/kinfitr_bloodfuncs.R
+++ b/R/kinfitr_bloodfuncs.R
@@ -672,9 +672,14 @@ blood_smooth <- function(time, activity, iterations = 1) {
 #' @param taper_weights Should the weights be tapered to gradually trade off
 #'   between the continuous and discrete samples after the peak?
 #' @param weightscheme Which weighting scheme should be used before
-#'   accommodating Method_divide and taper_weights? 1 represents a uniform
-#'   weighting before accommodating Method_divide and taper_weights. 2
-#'   represents time/AIF as used by Columbia PET Centre. Default is 2.
+#'   accommodating Method_divide and taper_weights? Options are: 1 = uniform
+#'   weighting; 2 = time/AIF as used by Columbia PET Centre; 3 = absolute value
+#'   of activity (weights proportional to the measured radioactivity); 4 =
+#'   square root of the absolute value of activity; 5 = squared activity. The
+#'   latter three (3, 4, 5) make weights rise with activity (the opposite of
+#'   variance-stabilising weighting) and are useful when fitting splines where
+#'   the user wants weight proportional to the estimated/measured magnitude.
+#'   Default is 2.
 #'
 #' @return A vector of model weights
 #' @export
@@ -713,9 +718,15 @@ blood_weights_create <- function(time, activity,
   # Set a minimum value to prevent extreme weights
   blood$activity[blood$activity < max(blood$activity / 1e4)] <-  max(blood$activity / 1e4)
 
-  basicweights <- dplyr::case_when(
-    weightscheme==1 ~ 1,
-    weightscheme==2 ~ blood$time / blood$activity,
+  basicweights <- switch(
+    as.character(weightscheme),
+    "1" = rep(1, nrow(blood)),
+    "2" = blood$time / blood$activity,
+    "3" = abs(blood$activity),
+    "4" = sqrt(abs(blood$activity)),
+    "5" = blood$activity^2,
+    stop("Unrecognised weightscheme: ", weightscheme,
+         ". Must be one of 1, 2, 3, 4, 5.")
   )
 
   out <- basicweights * blood$weights

--- a/R/kinfitr_bloodmodels.R
+++ b/R/kinfitr_bloodmodels.R
@@ -1,3 +1,27 @@
+# Internal: detect a scam-only basis name. Currently only mpi (monotone
+# increasing) and mpd (monotone decreasing) are supported via blmod_splines.
+is_scam_basis <- function(bs) {
+  bs %in% c("mpi", "mpd")
+}
+
+# Internal: fit dispatcher. Routes scam bases to scam::scam, otherwise mgcv::gam.
+# Both engines accept the same s(x, bs=..., k=...) formula and both have predict
+# methods that dispatch on object class, so downstream code is unchanged.
+# scam::scam crashes on exactly-zero weights (mgcv tolerates them), so for the
+# scam branch we filter zero-weight rows before fitting.
+fit_spline <- function(formula, data, weights, bs) {
+  if (is_scam_basis(bs)) {
+    keep <- weights > 0
+    do.call(scam::scam,
+            list(formula = formula,
+                 data = data[keep, , drop = FALSE],
+                 weights = weights[keep]))
+  } else {
+    mgcv::gam(formula, data = data, weights = weights)
+  }
+}
+
+
 #' Blood Model: Tidy inputs
 #'
 #' Tidies the inputs to blood models ready for modelling
@@ -100,21 +124,46 @@ blmod_tidyinput <- function(time, activity, Method = NULL, weights = NULL) {
 #'   gradually trade off between the continuous and discrete samples after the
 #'   peak?
 #' @param weightscheme If no weights provided, which weighting scheme should be
-#'   used before accommodating Method_divide and taper_weights? 1 represents a
-#'   uniform weighting before accommodating Method_divide and taper_weights. 2
-#'   represents time/AIF as used by Columbia PET Centre. Default is 2.
+#'   used before accommodating Method_divide and taper_weights? Options are: 1
+#'   = uniform weighting; 2 = time/AIF as used by Columbia PET Centre; 3 =
+#'   absolute value of activity (weights proportional to the measured
+#'   radioactivity); 4 = square root of the absolute value of activity; 5 =
+#'   squared activity. Schemes 3-5 make weights rise with activity, the
+#'   opposite of variance-stabilising weighting. Default is 2.
 #' @param bs_before Optional. Defines the basis function for the points before
-#'   the peak.
+#'   the peak. The default is \code{"mpi"}, the monotone-increasing basis from
+#'   the \code{scam} package, which constrains the pre-peak rise to be
+#'   non-decreasing and works well with the t0 estimation below. Any
+#'   \code{mgcv} basis name (e.g. \code{"cr"}) is also valid; \code{"mpi"} and
+#'   \code{"mpd"} dispatch to \code{scam::scam}, all others to
+#'   \code{mgcv::gam}.
 #' @param bs_after_c Optional. Defines the basis function for the continuous
-#'   points after the peak.
+#'   points after the peak. Default is \code{"cr"}. Set to \code{"mpd"} to
+#'   enforce a monotone-decreasing tail.
 #' @param bs_after_d Optional. Defines the basis function for the discrete
-#'   points after the peak.
+#'   points after the peak. Default is \code{"cr"}. Set to \code{"mpd"} to
+#'   enforce a monotone-decreasing tail.
 #' @param k_before Optional. Defines the dimension of the basis for the points
 #'   before the peak.
 #' @param k_after_c Optional. Defines the dimension of the basis for the
 #'   continuous points after the peak.
 #' @param k_after_d Optional. Defines the dimension of the basis for the
 #'   discrete points after the peak.
+#' @param t0.lower Lower bound for the fitted t0 onset time (in seconds, the
+#'   units of \code{time}). Predictions for \code{time < t0} are forced to
+#'   zero. Default 0.
+#' @param t0.upper Upper bound for the fitted t0 onset time (in seconds). If
+#'   \code{NULL} (default), it is set to \code{peaktime} since t0 must be no
+#'   later than the peak by construction.
+#' @param t0_use_monotonic Logical. When \code{FALSE} (default), the t0 search
+#'   uses \code{mgcv::gam} with \code{bs = "cr"} regardless of
+#'   \code{bs_before}, because the inner fit runs dozens of times inside
+#'   \code{stats::optimize} and \code{scam::scam} is much slower per fit. The
+#'   final spline at the estimated t0 still uses the user's \code{bs_before}.
+#'   When \code{TRUE}, the t0 search uses \code{bs_before} (so the monotone
+#'   constraint applies during onset search if \code{bs_before} is a scam
+#'   basis like \code{"mpi"}) — slower, but the monotone constraint can in
+#'   some cases yield a better-defined onset.
 #'
 #' @return A model fit including all of the individual models of class
 #'   blood_splines.
@@ -131,8 +180,9 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
                           Method_weights = TRUE,
                           taper_weights = TRUE,
                           weightscheme=2,
-                          bs_before="cr", bs_after_c="cr", bs_after_d="cr",
-                          k_before=-1, k_after_c=-1, k_after_d=-1) {
+                          bs_before="mpi", bs_after_c="cr", bs_after_d="cr",
+                          k_before=-1, k_after_c=-1, k_after_d=-1,
+                          t0.lower=0, t0.upper=NULL, t0_use_monotonic=FALSE) {
 
   blood <- blmod_tidyinput(time, activity, Method, weights)
 
@@ -145,9 +195,58 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
 
   peaktime <- blood$time[blood$activity == max(blood$activity)]
 
-  before_peak <- dplyr::filter(blood, time <= peaktime)
-  before_peak$time [ nrow(before_peak) ] <-
-    before_peak$time [ nrow(before_peak) ] - 0.001 # predict until nearly there
+  # ---- Estimate t0: onset before which predicted activity is 0 ----
+  # Mirrors the strategy in spline_tac() (R/kinfitr_spline_tac.R). Only the
+  # before-peak segment is affected; the after-peak splines use log(time) and
+  # are independent of t0.
+  before_peak_full <- dplyr::filter(blood, time <= peaktime)
+  if ("Continuous" %in% Method) {
+    before_peak_full <- dplyr::filter(before_peak_full, Method == "Continuous")
+  }
+
+  full_t <- before_peak_full$time
+  full_y <- before_peak_full$activity
+  full_w <- before_peak_full$weights
+
+  # The t0 search runs the inner spline fit dozens of times. By default we use
+  # mgcv::gam with bs="cr" here regardless of the user's bs_before — finding
+  # the onset doesn't require shape constraints, and scam::scam is much slower
+  # per fit. When t0_use_monotonic=TRUE the user's bs_before is used for the
+  # search instead (slower, but the monotone constraint can give a more
+  # well-defined onset). Either way the final fit at the estimated t0 uses
+  # bs_before.
+  bs_t0 <- if (t0_use_monotonic) bs_before else "cr"
+  t0_objective <- function(t0_val) {
+    mask <- full_t >= t0_val
+    if (sum(mask) < 3) return(1e10)
+    d <- data.frame(t_adj = full_t[mask] - t0_val,
+                    activity = full_y[mask])
+    k_t0 <- if (k_before == -1) -1 else min(k_before, sum(mask) - 2)
+    fit <- try(fit_spline(activity ~ s(t_adj, bs = bs_t0, k = k_t0),
+                          data = d, weights = full_w[mask], bs = bs_t0),
+               silent = TRUE)
+    if (inherits(fit, "try-error")) return(1e10)
+    pred <- rep(0, length(full_t))
+    pred[mask] <- pmax(0, as.numeric(predict(fit, newdata = d)))
+    sum((full_y - pred)^2)
+  }
+
+  t0_upper_use <- if (is.null(t0.upper)) peaktime else t0.upper
+  if (t0_upper_use > t0.lower) {
+    opt <- stats::optimize(t0_objective,
+                           interval = c(t0.lower, t0_upper_use),
+                           tol = 1e-4)
+    t0 <- opt$minimum
+  } else {
+    t0 <- t0.lower
+  }
+
+  # ---- Fit before-peak spline in t_adj = time - t0 coordinates ----
+  before_peak <- dplyr::filter(blood, time >= t0, time <= peaktime)
+  before_peak$t_adj <- before_peak$time - t0
+  # predict until nearly there: preserved from original behaviour
+  before_peak$t_adj[ nrow(before_peak) ] <-
+    before_peak$t_adj[ nrow(before_peak) ] - 0.001
 
   # Check knots
   if( nrow(before_peak) < 12 ) {
@@ -181,17 +280,17 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
     }
 
     # Fit
-    before <- mgcv::gam(activity ~ s(time, bs = bs_before, k=k_before),
-                        weights = weights,
-                        data = before_peak)
+    before <- fit_spline(activity ~ s(t_adj, bs = bs_before, k=k_before),
+                         data = before_peak, weights = before_peak$weights,
+                         bs = bs_before)
 
-    after_d <- mgcv::gam(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
-                         weights = weights,
-                         data = after_peak_d)
+    after_d <- fit_spline(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
+                          data = after_peak_d, weights = after_peak_d$weights,
+                          bs = bs_after_d)
 
-    after_c <- mgcv::gam(activity ~ s(log(time), bs = bs_after_c, k=k_after_c),
-                         weights = weights,
-                         data = after_peak_c)
+    after_c <- fit_spline(activity ~ s(log(time), bs = bs_after_c, k=k_after_c),
+                          data = after_peak_c, weights = after_peak_c$weights,
+                          bs = bs_after_c)
 
     start_overlap <- min(after_peak_d$time)
     stop_overlap <- max(after_peak_c$time)
@@ -208,17 +307,17 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
     }
 
     # Fit
-    before <- mgcv::gam(activity ~ s(time, bs = bs_before, k=k_before),
-                        weights = weights,
-                        data = before_peak)
+    before <- fit_spline(activity ~ s(t_adj, bs = bs_before, k=k_before),
+                         data = before_peak, weights = before_peak$weights,
+                         bs = bs_before)
 
-    after_d <- mgcv::gam(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
-                         weights = weights,
-                         data = after_peak)
+    after_d <- fit_spline(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
+                          data = after_peak, weights = after_peak$weights,
+                          bs = bs_after_d)
 
-    after_c <- mgcv::gam(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
-                         weights = weights,
-                         data = after_peak)
+    after_c <- fit_spline(activity ~ s(log(time), bs = bs_after_d, k=k_after_d),
+                          data = after_peak, weights = after_peak$weights,
+                          bs = bs_after_d)
 
     start_overlap <- peaktime
     stop_overlap <- max(after_peak$time)
@@ -231,6 +330,7 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
     peaktime = peaktime,
     start_overlap = start_overlap,
     stop_overlap = stop_overlap,
+    t0 = t0,
     time = blood$time
   )
 
@@ -261,11 +361,14 @@ blmod_splines <- function(time, activity, Method = NULL, weights = NULL,
 #' @export
 predict_blood_splines <- function(object, newdata = NULL) {
 
+  t0 <- if (!is.null(object$t0)) object$t0 else 0
+
   if (is.null(newdata)) {
     pred_before <- as.numeric(predict(object$before))
-    pred_x_before <- object$before$model$time
+    # before-spline is fit in t_adj = time - t0; back-transform to raw time
+    pred_x_before <- object$before$model$t_adj + t0
 
-    # Remove our extra point before the peak
+    # Remove our extra point before the peak (the -0.001 nudge sample)
     pred_before <- pred_before[-length(pred_before)]
     pred_x_before <- pred_x_before[-length(pred_x_before)]
 
@@ -289,9 +392,17 @@ predict_blood_splines <- function(object, newdata = NULL) {
   newdata_nozero$time <- ifelse(newdata_nozero$time < 0.00001,
                                 yes = 0.00001, no = newdata_nozero$time)
 
-  pred_before <-  as.numeric(predict(object$before, newdata = newdata))
+  # before-spline newdata uses t_adj coordinates (clip negatives to 0 so the
+  # spline isn't extrapolated below its fitted domain — predictions there are
+  # forced to 0 below anyway)
+  newdata_before <- list(t_adj = pmax(newdata$time - t0, 0))
+
+  pred_before <-  as.numeric(predict(object$before, newdata = newdata_before))
   pred_after_d <- as.numeric(predict(object$after_d, newdata = newdata_nozero))
   pred_after_c <- as.numeric(predict(object$after_c, newdata = newdata_nozero))
+
+  # Force pre-t0 predictions to zero
+  pred_before[newdata$time < t0] <- 0
 
   pred_before <- tibble::tibble(time = newdata$time,
                                 activity = pred_before)
@@ -336,6 +447,13 @@ predict_blood_splines <- function(object, newdata = NULL) {
   pred <- dplyr::bind_rows(pred_before, pred_after)
 
   preds <- dplyr::pull(pred, activity)
+
+  # Activity is bounded at zero — clip any negative predictions. This matches
+  # the spline_tac() pattern and the user's stated requirement that the spline
+  # never go negative in its estimated values. Negative predictions can arise
+  # from spline extrapolation/wiggle (especially with monotone bases on very
+  # noisy early data).
+  preds[preds < 0] <- 0
 
   return(preds)
 }

--- a/man/blmod_splines.Rd
+++ b/man/blmod_splines.Rd
@@ -12,12 +12,15 @@ blmod_splines(
   Method_weights = TRUE,
   taper_weights = TRUE,
   weightscheme = 2,
-  bs_before = "cr",
+  bs_before = "mpi",
   bs_after_c = "cr",
   bs_after_d = "cr",
   k_before = -1,
   k_after_c = -1,
-  k_after_d = -1
+  k_after_d = -1,
+  t0.lower = 0,
+  t0.upper = NULL,
+  t0_use_monotonic = FALSE
 )
 }
 \arguments{
@@ -39,18 +42,28 @@ gradually trade off between the continuous and discrete samples after the
 peak?}
 
 \item{weightscheme}{If no weights provided, which weighting scheme should be
-used before accommodating Method_divide and taper_weights? 1 represents a
-uniform weighting before accommodating Method_divide and taper_weights. 2
-represents time/AIF as used by Columbia PET Centre. Default is 2.}
+used before accommodating Method_divide and taper_weights? Options are: 1
+= uniform weighting; 2 = time/AIF as used by Columbia PET Centre; 3 =
+absolute value of activity (weights proportional to the measured
+radioactivity); 4 = square root of the absolute value of activity; 5 =
+squared activity. Schemes 3-5 make weights rise with activity, the
+opposite of variance-stabilising weighting. Default is 2.}
 
 \item{bs_before}{Optional. Defines the basis function for the points before
-the peak.}
+the peak. The default is \code{"mpi"}, the monotone-increasing basis from
+the \code{scam} package, which constrains the pre-peak rise to be
+non-decreasing and works well with the t0 estimation below. Any
+\code{mgcv} basis name (e.g. \code{"cr"}) is also valid; \code{"mpi"} and
+\code{"mpd"} dispatch to \code{scam::scam}, all others to
+\code{mgcv::gam}.}
 
 \item{bs_after_c}{Optional. Defines the basis function for the continuous
-points after the peak.}
+points after the peak. Default is \code{"cr"}. Set to \code{"mpd"} to
+enforce a monotone-decreasing tail.}
 
 \item{bs_after_d}{Optional. Defines the basis function for the discrete
-points after the peak.}
+points after the peak. Default is \code{"cr"}. Set to \code{"mpd"} to
+enforce a monotone-decreasing tail.}
 
 \item{k_before}{Optional. Defines the dimension of the basis for the points
 before the peak.}
@@ -60,6 +73,24 @@ continuous points after the peak.}
 
 \item{k_after_d}{Optional. Defines the dimension of the basis for the
 discrete points after the peak.}
+
+\item{t0.lower}{Lower bound for the fitted t0 onset time (in seconds, the
+units of \code{time}). Predictions for \code{time < t0} are forced to
+zero. Default 0.}
+
+\item{t0.upper}{Upper bound for the fitted t0 onset time (in seconds). If
+\code{NULL} (default), it is set to \code{peaktime} since t0 must be no
+later than the peak by construction.}
+
+\item{t0_use_monotonic}{Logical. When \code{FALSE} (default), the t0 search
+uses \code{mgcv::gam} with \code{bs = "cr"} regardless of
+\code{bs_before}, because the inner fit runs dozens of times inside
+\code{stats::optimize} and \code{scam::scam} is much slower per fit. The
+final spline at the estimated t0 still uses the user's \code{bs_before}.
+When \code{TRUE}, the t0 search uses \code{bs_before} (so the monotone
+constraint applies during onset search if \code{bs_before} is a scam
+basis like \code{"mpi"}) — slower, but the monotone constraint can in
+some cases yield a better-defined onset.}
 }
 \value{
 A model fit including all of the individual models of class

--- a/man/blood_weights_create.Rd
+++ b/man/blood_weights_create.Rd
@@ -29,9 +29,14 @@ continuous samples each get less weight). Default is TRUE.}
 between the continuous and discrete samples after the peak?}
 
 \item{weightscheme}{Which weighting scheme should be used before
-accommodating Method_divide and taper_weights? 1 represents a uniform
-weighting before accommodating Method_divide and taper_weights. 2
-represents time/AIF as used by Columbia PET Centre. Default is 2.}
+accommodating Method_divide and taper_weights? Options are: 1 = uniform
+weighting; 2 = time/AIF as used by Columbia PET Centre; 3 = absolute value
+of activity (weights proportional to the measured radioactivity); 4 =
+square root of the absolute value of activity; 5 = squared activity. The
+latter three (3, 4, 5) make weights rise with activity (the opposite of
+variance-stabilising weighting) and are useful when fitting splines where
+the user wants weight proportional to the estimated/measured magnitude.
+Default is 2.}
 }
 \value{
 A vector of model weights


### PR DESCRIPTION
## Summary

  Adds three capabilities to `blmod_splines()` that have been useful when fitting noisy AIF/blood data:

  1. **t0 onset estimation.** Mirroring `spline_tac()`, the function now estimates a `t0` time before which predicted activity is
  forced to zero. The before-peak spline is fit in `t_adj = time - t0` coordinates and `t0` is found by `stats::optimize()` over
  `[t0.lower, t0.upper]` (default `t0.upper = peaktime`). This stops the pre-peak spline from wiggling around zero on noisy early
  samples and gives a clean onset.

  2. **Monotone splines via `scam`.** Setting any of `bs_before` / `bs_after_c` / `bs_after_d` to `"mpi"` (monotone increasing) or
  `"mpd"` (monotone decreasing) routes that segment through `scam::scam` instead of `mgcv::gam`. Engine dispatch happens
  automatically via a small `is_scam_basis()` helper — no separate flag. The new default `bs_before = "mpi"` enforces a
  non-decreasing rise to peak, which pairs naturally with the t0 search.

  3. **Three new weighting schemes** in `blood_weights_create()`, intended for users who want weights proportional to the measured
  magnitude rather than variance-stabilising:
     - `weightscheme = 3` → `|activity|`
     - `weightscheme = 4` → `sqrt(|activity|)`
     - `weightscheme = 5` → `activity^2`

  ## Performance

  The t0 search runs the inner spline fit dozens of times per call. By default it uses `mgcv::gam(bs="cr")` regardless of
  `bs_before` — onset location doesn't require shape constraints, and this keeps a 6-subject batch at ~3 s. A new `t0_use_monotonic
   = FALSE` flag lets users opt into using the user-specified `bs_before` (i.e. `scam::scam` if `mpi`) for the t0 search — slower
  (~40 s/subject on real AIF data) but produces a better-defined onset when early samples are very noisy. The final fit at the
  estimated `t0` always uses the user's `bs_before`.

  ## Other changes

  - `predict_blood_splines()` now clips negative predictions to zero (matching `spline_tac()` and the stated requirement that the
  spline should never go negative).
  - Fixed a latent bug in the three `mgcv::gam` calls where `weights = weights` referenced the outer (NULL-by-default) argument
  instead of the per-row weights in the data frame.
  - `blood_weights_create()` switched from `dplyr::case_when()` to `switch()` to silence the dplyr 1.2.0 scalar-LHS/vector-RHS
  deprecation warning that the new clauses would otherwise trigger.
  - `scam` added to `Imports:` (required by the new `mpi` default).

  ## API changes / breaking

  - New default `bs_before = "mpi"` (was `"cr"`). Callers who relied on the previous unconstrained `cr` behaviour should pass
  `bs_before = "cr"` explicitly.
  - New fields on returned objects: `$t0`.
  - The before-spline's training column is now `t_adj` (was `time`); any external code that read `fit$before$model$time` directly
  will need to use `fit$before$model$t_adj + fit$t0`.

  ## Test plan
  
  - [x] Existing `tests/testthat/test-blooddata.R::"bloodsplines works"` passes with new defaults
  - [x] Full test suite green (458/458)
  - [x] Manual run on 6-subject AIF dataset (`test_bloodsplines.rmd`): all subjects fit successfully, all predictions ≥ 0, t0 lies
  in `[0, peaktime]`; monotone-t0 mode gives visibly better onset estimates on subjects with noisy early samples
